### PR TITLE
Normalize Firestore event schema and refine organizer event detail UI

### DIFF
--- a/CodeBase/.gitignore
+++ b/CodeBase/.gitignore
@@ -15,4 +15,5 @@
 local.properties
 .idea/
 build/
+/.gradle-user-home/
 app/google-services.json

--- a/CodeBase/app/src/main/java/com/example/codebase/CancelledEntrantsActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/CancelledEntrantsActivity.java
@@ -128,10 +128,16 @@ public class CancelledEntrantsActivity extends AppCompatActivity {
             return;
         }
 
-        // ── Read arrays ───────────────────────────────────────────────────────
-        List<String> selected  = toStringList(doc.get("selectedEntrants"));
-        List<String> enrolled  = toStringList(doc.get("enrolledEntrants"));
-        List<String> cancelled = toStringList(doc.get("cancelledEntrants"));
+        Event event = EventSchema.normalizeLoadedEvent(doc);
+        if (event == null) {
+            Toast.makeText(this, "Event not found", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
+
+        List<String> selected = event.getSelectedEntrants();
+        List<String> enrolled = event.getEnrolledEntrants();
+        List<String> cancelled = event.getCancelledEntrants();
 
         // ── Calculate declined ────────────────────────────────────────────────
         // Declined = cancelledEntrants ∩ (selectedEntrants - enrolledEntrants)
@@ -200,19 +206,6 @@ public class CancelledEntrantsActivity extends AppCompatActivity {
     }
 
     // ─── Helper ───────────────────────────────────────────────────────────────
-
-    @SuppressWarnings("unchecked")
-    private List<String> toStringList(Object obj) {
-        if (obj instanceof List) {
-            List<?> raw = (List<?>) obj;
-            List<String> result = new ArrayList<>();
-            for (Object item : raw) {
-                if (item instanceof String) result.add((String) item);
-            }
-            return result;
-        }
-        return new ArrayList<>();
-    }
 
     // ─── Model ────────────────────────────────────────────────────────────────
 

--- a/CodeBase/app/src/main/java/com/example/codebase/CreateEventActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/CreateEventActivity.java
@@ -24,9 +24,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 
 public class CreateEventActivity extends AppCompatActivity {
 
@@ -53,10 +51,10 @@ public class CreateEventActivity extends AppCompatActivity {
             viewModel.waitlistLimit = getIntent().getIntExtra("waitlistCap", -1);
             viewModel.capacity = getIntent().getIntExtra("capacity", 0);
             viewModel.posterBase64 = getIntent().getStringExtra("posterBase64") != null ? getIntent().getStringExtra("posterBase64") : "";
-            viewModel.eventStart = getIntent().getStringExtra("eventStart") != null ? getIntent().getStringExtra("eventStart") : "";
-            viewModel.eventEnd = getIntent().getStringExtra("eventEnd") != null ? getIntent().getStringExtra("eventEnd") : "";
-            viewModel.regOpen = getIntent().getStringExtra("regOpen") != null ? getIntent().getStringExtra("regOpen") : "";
-            viewModel.regClose = getIntent().getStringExtra("regClose") != null ? getIntent().getStringExtra("regClose") : "";
+            viewModel.startDate = readStringExtra("startDate", "eventStart");
+            viewModel.endDate = readStringExtra("endDate", "eventEnd");
+            viewModel.registrationOpen = readStringExtra("registrationOpen", "regOpen");
+            viewModel.registrationDeadline = readStringExtra("registrationDeadline", "regClose");
         }
 
 
@@ -128,6 +126,27 @@ public class CreateEventActivity extends AppCompatActivity {
         }
     }
 
+    private String readStringExtra(String primaryKey, String legacyKey) {
+        String value = getIntent().getStringExtra(primaryKey);
+        if (value == null) {
+            value = getIntent().getStringExtra(legacyKey);
+        }
+        return value != null ? value : "";
+    }
+
+    private void applyScheduleFields(Event event) {
+        Timestamp startTs = parseDate(viewModel.startDate);
+        Timestamp endTs = parseDate(viewModel.endDate);
+        Timestamp registrationOpenTs = parseDate(viewModel.registrationOpen);
+        Timestamp registrationDeadlineTs = parseDate(viewModel.registrationDeadline);
+
+        event.setStartDate(startTs != null ? startTs.toDate() : null);
+        event.setEndDate(endTs != null ? endTs.toDate() : null);
+        event.setRegistrationOpen(registrationOpenTs != null ? registrationOpenTs.toDate() : null);
+        event.setRegistrationDeadline(registrationDeadlineTs != null ? registrationDeadlineTs.toDate() : null);
+        event.setDrawDate(EventSchema.calculateDrawDate(event.getRegistrationDeadline()));
+    }
+
     private void publishEvent() {
         // Basic Validation
         if (viewModel.name.trim().isEmpty() || viewModel.capacity <= 0) {
@@ -145,31 +164,23 @@ public class CreateEventActivity extends AppCompatActivity {
 
         if (viewModel.isEditMode){
             db.collection("events").document(eventId).get().addOnSuccessListener(doc -> {
-                Event existing = doc.toObject(Event.class);
+                Event existing = EventSchema.normalizeLoadedEvent(doc);
+                if (existing == null) {
+                    btnContinue.setEnabled(true);
+                    btnContinue.setText("SAVE CHANGES");
+                    Toast.makeText(this, "Failed to load event", Toast.LENGTH_SHORT).show();
+                    return;
+                }
 
                 existing.setTitle(viewModel.name);
                 existing.setDescription(viewModel.description);
                 existing.setLocation(viewModel.location);
                 existing.setPrice((float) viewModel.price);
                 existing.setMaxCapacity((long) viewModel.capacity);
+                existing.setWinnersCount((long) viewModel.capacity);
                 existing.setWaitlistCap(viewModel.waitlistLimit);
                 existing.setGeoEnabled(viewModel.geoRequired);
-
-                Timestamp startTs    = parseDate(viewModel.eventStart);
-                Timestamp endTs      = parseDate(viewModel.eventEnd);
-                Timestamp regOpenTs  = parseDate(viewModel.regOpen);
-                Timestamp regCloseTs = parseDate(viewModel.regClose);
-                if (startTs != null)
-                    existing.setStartDate(startTs.toDate());
-
-                if (endTs != null)
-                    existing.setEndDate(endTs.toDate());
-
-                if (regOpenTs != null)
-                    existing.setRegistrationOpen(regOpenTs.toDate());
-
-                if (regCloseTs != null)
-                    existing.setRegistrationDeadline(regCloseTs.toDate());
+                applyScheduleFields(existing);
 
                 if (viewModel.posterBase64 != null && !viewModel.posterBase64.isEmpty())
                     existing.setPoster(new EventPoster(viewModel.posterBase64));
@@ -189,30 +200,15 @@ public class CreateEventActivity extends AppCompatActivity {
         } else {
             Event event = new Event();
             event.setId(eventId);
-
             event.setTitle(viewModel.name);
             event.setDescription(viewModel.description);
             event.setLocation(viewModel.location);
             event.setPrice((float) viewModel.price);
             event.setMaxCapacity((long) viewModel.capacity);
+            event.setWinnersCount((long) viewModel.capacity);
             event.setWaitlistCap(viewModel.waitlistLimit);
             event.setGeoEnabled(viewModel.geoRequired);
-
-            Timestamp startTs    = parseDate(viewModel.eventStart);
-            Timestamp endTs      = parseDate(viewModel.eventEnd);
-            Timestamp regOpenTs  = parseDate(viewModel.regOpen);
-            Timestamp regCloseTs = parseDate(viewModel.regClose);
-            if (startTs != null)
-                event.setStartDate(startTs.toDate());
-
-            if (endTs != null)
-                event.setEndDate(endTs.toDate());
-
-            if (regOpenTs != null)
-                event.setRegistrationOpen(regOpenTs.toDate());
-
-            if (regCloseTs != null)
-                event.setRegistrationDeadline(regCloseTs.toDate());
+            applyScheduleFields(event);
 
 
             // Poster Image (Base64)
@@ -221,10 +217,10 @@ public class CreateEventActivity extends AppCompatActivity {
 
             event.setOrganizerDeviceId(DeviceIdManager.getOrCreateDeviceId(this));
             event.setStatus("published");
-            event.setWaitingList(new ArrayList<Entrant>());
-            event.setSelectedEntrants(new ArrayList<Entrant>());
-            event.setCancelledEntrants(new ArrayList<Entrant>());
-            event.setEnrolledEntrants(new ArrayList<Entrant>());
+            event.setWaitingList(new ArrayList<>());
+            event.setSelectedEntrants(new ArrayList<>());
+            event.setCancelledEntrants(new ArrayList<>());
+            event.setEnrolledEntrants(new ArrayList<>());
 
             db.collection("events").document(eventId).set(event, SetOptions.merge())
                     .addOnSuccessListener(aVoid -> {

--- a/CodeBase/app/src/main/java/com/example/codebase/CreateEventViewModel.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/CreateEventViewModel.java
@@ -12,10 +12,10 @@ public class CreateEventViewModel extends ViewModel {
     public double price = 0.0;
 
     // Step 1: Schedule (Storing as strings for simplicity from the EditTexts)
-    public String eventStart = "";
-    public String eventEnd = "";
-    public String regOpen = "";
-    public String regClose = "";
+    public String startDate = "";
+    public String endDate = "";
+    public String registrationOpen = "";
+    public String registrationDeadline = "";
     public int capacity = 0;
 
     // Step 2: Settings

--- a/CodeBase/app/src/main/java/com/example/codebase/CreateScheduleFragment.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/CreateScheduleFragment.java
@@ -35,17 +35,17 @@ public class CreateScheduleFragment extends Fragment {
         EditText etCapacity = view.findViewById(R.id.etCapacity);
 
         // Pre-fill fields on navigation back
-        etEventStart.setText(viewModel.eventStart);
-        etEventEnd.setText(viewModel.eventEnd);
-        etRegOpen.setText(viewModel.regOpen);
-        etRegClose.setText(viewModel.regClose);
+        etEventStart.setText(viewModel.startDate);
+        etEventEnd.setText(viewModel.endDate);
+        etRegOpen.setText(viewModel.registrationOpen);
+        etRegClose.setText(viewModel.registrationDeadline);
         if (viewModel.capacity > 0) etCapacity.setText(String.valueOf(viewModel.capacity));
 
         // Use proper Calendar pickers
-        setupDatePicker(etEventStart, "Select Event Start Date", date -> viewModel.eventStart = date);
-        setupDatePicker(etEventEnd, "Select Event End Date", date -> viewModel.eventEnd = date);
-        setupDatePicker(etRegOpen, "Select Registration Open Date", date -> viewModel.regOpen = date);
-        setupDatePicker(etRegClose, "Select Registration Close Date", date -> viewModel.regClose = date);
+        setupDatePicker(etEventStart, "Select Event Start Date", date -> viewModel.startDate = date);
+        setupDatePicker(etEventEnd, "Select Event End Date", date -> viewModel.endDate = date);
+        setupDatePicker(etRegOpen, "Select Registration Open Date", date -> viewModel.registrationOpen = date);
+        setupDatePicker(etRegClose, "Select Registration Close Date", date -> viewModel.registrationDeadline = date);
 
         etCapacity.addTextChangedListener(new CreateEventFragment.SimpleTextWatcher() {
             @Override public void onTextChanged(CharSequence s, int start, int before, int count) {

--- a/CodeBase/app/src/main/java/com/example/codebase/Event.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/Event.java
@@ -1,9 +1,8 @@
 package com.example.codebase;
 
 import java.io.Serializable;
-import java.util.Date;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Date;
 
 public class Event implements Serializable {
     private String id;
@@ -22,13 +21,12 @@ public class Event implements Serializable {
     private String posterUrl;
     private Long maxCapacity;
     private Long winnersCount;
-    private ArrayList<Entrant> waitingList;
-    private ArrayList<Entrant> selectedEntrants;
-    private ArrayList<Entrant> enrolledEntrants;
+    private ArrayList<String> waitingList = new ArrayList<>();
+    private ArrayList<String> selectedEntrants = new ArrayList<>();
+    private ArrayList<String> enrolledEntrants = new ArrayList<>();
     private String status;
     private boolean geoEnabled;
-    private ArrayList<Entrant>  cancelledEntrants;
-
+    private ArrayList<String> cancelledEntrants = new ArrayList<>();
     private String eventId;
 
     public String getEventId() {
@@ -37,6 +35,7 @@ public class Event implements Serializable {
 
     public void setEventId(String eventId) {
         this.eventId = eventId;
+        this.id = eventId;
     }
 
     public boolean isGeoEnabled() {
@@ -61,6 +60,7 @@ public class Event implements Serializable {
 
     public void setId(String id) {
         this.id = id;
+        this.eventId = id;
     }
 
     public String getOrganizerDeviceId() {
@@ -111,35 +111,35 @@ public class Event implements Serializable {
         this.winnersCount = winnersCount;
     }
 
-    public ArrayList<Entrant> getWaitingList() {
+    public ArrayList<String> getWaitingList() {
         return waitingList;
     }
 
-    public void setWaitingList(ArrayList<Entrant> waitingList) {
+    public void setWaitingList(ArrayList<String> waitingList) {
         this.waitingList = waitingList;
     }
 
-    public ArrayList<Entrant> getSelectedEntrants() {
+    public ArrayList<String> getSelectedEntrants() {
         return selectedEntrants;
     }
 
-    public void setSelectedEntrants(ArrayList<Entrant> selectedEntrants) {
+    public void setSelectedEntrants(ArrayList<String> selectedEntrants) {
         this.selectedEntrants = selectedEntrants;
     }
 
-    public ArrayList<Entrant> getEnrolledEntrants() {
+    public ArrayList<String> getEnrolledEntrants() {
         return enrolledEntrants;
     }
 
-    public void setEnrolledEntrants(ArrayList<Entrant> enrolledEntrants) {
+    public void setEnrolledEntrants(ArrayList<String> enrolledEntrants) {
         this.enrolledEntrants = enrolledEntrants;
     }
 
-    public ArrayList<Entrant> getCancelledEntrants() {
+    public ArrayList<String> getCancelledEntrants() {
         return cancelledEntrants;
     }
 
-    public void setCancelledEntrants(ArrayList<Entrant>  cancelledEntrants) {
+    public void setCancelledEntrants(ArrayList<String> cancelledEntrants) {
         this.cancelledEntrants = cancelledEntrants;
     }
 
@@ -215,5 +215,3 @@ public class Event implements Serializable {
         this.price = price;
     }
 }
-
-

--- a/CodeBase/app/src/main/java/com/example/codebase/EventDetailActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/EventDetailActivity.java
@@ -7,14 +7,12 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.lifecycle.ViewModelProvider;
 
-import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 
+import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -22,11 +20,11 @@ import java.util.Locale;
 /**
  * EventDetailActivity — Event detail screen for Organizer role.
  *
- * Reads from Firestore:
+ * Reads canonical event fields from Firestore:
  *   title, description, location
- *   eventStart, eventEnd, regClose (Timestamps); drawDate = regClose + 3 days (calculated)
- *   maxCapacity, winnersCount
- *   waitingList, selectedEntrants, enrolledEntrants, cancelledEntrants (arrays)
+ *   startDate, endDate, registrationOpen, registrationDeadline, drawDate
+ *   maxCapacity, waitlistCap
+ *   waitingList, selectedEntrants, enrolledEntrants, cancelledEntrants
  *
  * Status badge is calculated in real time from dates + arrays.
  * Firestore status field is NOT used.
@@ -54,9 +52,14 @@ public class EventDetailActivity extends AppCompatActivity {
     private TextView tvWaitingListRowCount;
     private TextView tvMaxCapacity;
     private TextView tvWinnersCount;
+    private TextView tvEventCost;
     private android.widget.ImageView ivHeroPoster;
     private View progressBar;
     private Event event;
+    private final SimpleDateFormat displayDateFormat =
+            new SimpleDateFormat("MMM dd, yyyy", Locale.getDefault());
+    private final NumberFormat currencyFormat =
+            NumberFormat.getCurrencyInstance(Locale.getDefault());
 
     private final SimpleDateFormat displayFormat =
             new SimpleDateFormat("MMM dd, yyyy · HH:mm", Locale.getDefault());
@@ -82,6 +85,7 @@ public class EventDetailActivity extends AppCompatActivity {
         tvWaitingListRowCount = findViewById(R.id.tvWaitingListRowCount);
         tvMaxCapacity = findViewById(R.id.tvMaxCapacity);
         tvWinnersCount = findViewById(R.id.tvWinnersCount);
+        tvEventCost = findViewById(R.id.tvEventCost);
         ivHeroPoster = findViewById(R.id.ivHeroPoster);
         progressBar = findViewById(R.id.detailProgressBar);
 
@@ -146,17 +150,18 @@ public class EventDetailActivity extends AppCompatActivity {
             intent.putExtra("capacity", event.getMaxCapacity() != null ? event.getMaxCapacity().intValue() : 0);
             intent.putExtra("posterBase64", event.getPoster() != null ? event.getPoster().getPosterImageBase64() : "");
 
-            if (event.getStartDate() != null)
-                intent.putExtra("eventStart", sdf.format(event.getStartDate()));
+            if (event.getStartDate() != null) {
+                intent.putExtra("startDate", sdf.format(event.getStartDate()));
+            }
 
             if (event.getEndDate() != null)
-                intent.putExtra("eventEnd", sdf.format(event.getEndDate()));
+                intent.putExtra("endDate", sdf.format(event.getEndDate()));
 
             if (event.getRegistrationOpen() != null)
-                intent.putExtra("regOpen", sdf.format(event.getRegistrationOpen()));
+                intent.putExtra("registrationOpen", sdf.format(event.getRegistrationOpen()));
 
             if (event.getRegistrationDeadline() != null)
-                intent.putExtra("regClose", sdf.format(event.getRegistrationDeadline()));
+                intent.putExtra("registrationDeadline", sdf.format(event.getRegistrationDeadline()));
 
             startActivity(intent);
         });
@@ -209,10 +214,19 @@ public class EventDetailActivity extends AppCompatActivity {
             return;
         }
 
-        event = doc.toObject(Event.class);
+        event = EventSchema.normalizeLoadedEvent(doc);
+        if (event == null) {
+            Toast.makeText(this,
+                    getString(R.string.error_event_not_found),
+                    Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
 
         // ── Poster image — stored as Base64 string in Firestore ──────────────
-        if (event.getPoster().getPosterImageBase64() != null && !event.getPoster().getPosterImageBase64().isEmpty()) {
+        if (event.getPoster() != null
+                && event.getPoster().getPosterImageBase64() != null
+                && !event.getPoster().getPosterImageBase64().isEmpty()) {
             try {
                 android.graphics.Bitmap bitmap = EventPoster.decodeImage(event.getPoster().getPosterImageBase64());
                 if (bitmap != null) {
@@ -245,33 +259,39 @@ public class EventDetailActivity extends AppCompatActivity {
         // ── Timestamps ────────────────────────────────────────────────────────
         Date regOpen = event.getRegistrationOpen() != null ? event.getRegistrationOpen() : null;
         Date registrationDeadline = event.getRegistrationDeadline() != null ? event.getRegistrationDeadline() : null;
-        // drawDate = regClose + 3 days (calculated, not stored in Firestore)
         Date drawDate = event.getDrawDate() != null ? event.getDrawDate() : null;
         Date startDate = event.getStartDate() != null ? event.getStartDate()  : null;
         Date endDate = event.getEndDate() != null ? event.getEndDate() : null;
 
-        // Display startDate on hero area
-        tvDetailDate.setText(startDate != null
-                ? displayFormat.format(startDate) : getString(R.string.date_not_set));
+        tvDetailDate.setText(formatEventDateRange(startDate, endDate));
 
         // ── Capacity fields ───────────────────────────────────────────────────
-        Long maxCapacity = (long) event.getWaitlistCap();
-        Long winnersCount = event.getMaxCapacity();
+        Long maxCapacity = event.getMaxCapacity();
+        int waitlistCap = event.getWaitlistCap();
+        float price = event.getPrice();
+
+        if (tvEventCost != null) {
+            tvEventCost.setText(currencyFormat.format(price));
+        }
 
         if (tvMaxCapacity != null) {
             tvMaxCapacity.setText((maxCapacity != null && maxCapacity > 0)
                     ? String.valueOf(maxCapacity) : "—");
         }
+        if (tvMaxCapacity != null && (maxCapacity == null || maxCapacity <= 0)) {
+            tvMaxCapacity.setText(getString(R.string.not_applicable_short));
+        }
         if (tvWinnersCount != null) {
-            tvWinnersCount.setText(winnersCount != null
-                    ? String.valueOf(winnersCount) : "—");
+            tvWinnersCount.setText(waitlistCap > 0
+                    ? String.valueOf(waitlistCap)
+                    : getString(R.string.not_applicable_short));
         }
 
         // ── Arrays ────────────────────────────────────────────────────────────
-        ArrayList<?> waitingList = (ArrayList<?>) event.getWaitingList();
-        ArrayList<?> selectedEntrants = (ArrayList<?>) event.getSelectedEntrants();
-        ArrayList<?> enrolledEntrants = (ArrayList<?>) event.getEnrolledEntrants();
-        ArrayList<?> cancelledEntrants = (ArrayList<?>) event.getCancelledEntrants();
+        List<String> waitingList = event.getWaitingList();
+        List<String> selectedEntrants = event.getSelectedEntrants();
+        List<String> enrolledEntrants = event.getEnrolledEntrants();
+        List<String> cancelledEntrants = event.getCancelledEntrants();
 
         int waitingCount = waitingList != null ? waitingList.size() : 0;
         int invitedCount = selectedEntrants != null ? selectedEntrants.size() : 0;
@@ -348,6 +368,23 @@ public class EventDetailActivity extends AppCompatActivity {
     }
 
     // ─── Apply status badge color + text ─────────────────────────────────────
+
+    private String formatEventDateRange(Date startDate, Date endDate) {
+        if (startDate == null) {
+            return getString(R.string.date_not_set);
+        }
+
+        if (endDate == null) {
+            return displayDateFormat.format(startDate);
+        }
+
+        String startText = displayDateFormat.format(startDate);
+        String endText = displayDateFormat.format(endDate);
+        if (startText.equals(endText)) {
+            return startText;
+        }
+        return startText + " - " + endText;
+    }
 
     private void applyStatusBadge(String status) {
         tvStatusBadge.setText(status);

--- a/CodeBase/app/src/main/java/com/example/codebase/EventRepository.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/EventRepository.java
@@ -37,17 +37,9 @@ public class EventRepository {
 
                     for (QueryDocumentSnapshot doc : queryDocumentSnapshots) {
                         try {
-                            Event event = doc.toObject(Event.class);
+                            Event event = EventSchema.normalizeLoadedEvent(doc);
 
                             if (event == null) continue;
-
-                            if (event.getEventId() == null || event.getEventId().isEmpty()) {
-                                event.setEventId(doc.getId());
-                            }
-
-                            if (event.getId() == null || event.getId().isEmpty()) {
-                                event.setId(doc.getId());
-                            }
 
                             if (isEventActive(event)) {
                                 events.add(event);
@@ -88,15 +80,7 @@ public class EventRepository {
                 .addOnSuccessListener(documentSnapshot -> {
                     if (documentSnapshot.exists()) {
                         try {
-                            Event event = documentSnapshot.toObject(Event.class);
-                            if (event != null) {
-                                if (event.getEventId() == null || event.getEventId().isEmpty()) {
-                                    event.setEventId(documentSnapshot.getId());
-                                }
-                                if (event.getId() == null || event.getId().isEmpty()) {
-                                    event.setId(documentSnapshot.getId());
-                                }
-                            }
+                            Event event = EventSchema.normalizeLoadedEvent(documentSnapshot);
                             callback.onEventLoaded(event);
                         } catch (Exception e) {
                             callback.onError(e);

--- a/CodeBase/app/src/main/java/com/example/codebase/EventSchema.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/EventSchema.java
@@ -1,0 +1,103 @@
+package com.example.codebase;
+
+import com.google.firebase.firestore.DocumentSnapshot;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Firestore schema helpers for event documents.
+ */
+public final class EventSchema {
+
+    private static final int DRAW_OFFSET_DAYS = 3;
+
+    private EventSchema() {
+    }
+
+    public static Event normalizeLoadedEvent(DocumentSnapshot documentSnapshot) {
+        if (documentSnapshot == null || !documentSnapshot.exists()) {
+            return null;
+        }
+
+        Event event = normalizeLoadedEvent(documentSnapshot.toObject(Event.class), documentSnapshot.getId());
+        if (event == null) {
+            return null;
+        }
+
+        event.setWaitingList(toDeviceIdList(documentSnapshot.get("waitingList")));
+        event.setSelectedEntrants(toDeviceIdList(documentSnapshot.get("selectedEntrants")));
+        event.setEnrolledEntrants(toDeviceIdList(documentSnapshot.get("enrolledEntrants")));
+        event.setCancelledEntrants(toDeviceIdList(documentSnapshot.get("cancelledEntrants")));
+        return event;
+    }
+
+    public static Event normalizeLoadedEvent(Event event, String documentId) {
+        if (event == null) {
+            return null;
+        }
+
+        if ((event.getId() == null || event.getId().isEmpty()) && documentId != null) {
+            event.setId(documentId);
+        } else if (event.getId() != null && !event.getId().isEmpty()) {
+            event.setEventId(event.getId());
+        }
+
+        if (event.getWaitingList() == null) {
+            event.setWaitingList(new ArrayList<>());
+        }
+        if (event.getSelectedEntrants() == null) {
+            event.setSelectedEntrants(new ArrayList<>());
+        }
+        if (event.getEnrolledEntrants() == null) {
+            event.setEnrolledEntrants(new ArrayList<>());
+        }
+        if (event.getCancelledEntrants() == null) {
+            event.setCancelledEntrants(new ArrayList<>());
+        }
+
+        if (event.getDrawDate() == null) {
+            event.setDrawDate(calculateDrawDate(event.getRegistrationDeadline()));
+        }
+
+        if (event.getWinnersCount() == null && event.getMaxCapacity() != null) {
+            event.setWinnersCount(event.getMaxCapacity());
+        }
+
+        return event;
+    }
+
+    public static Date calculateDrawDate(Date registrationDeadline) {
+        if (registrationDeadline == null) {
+            return null;
+        }
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(registrationDeadline);
+        calendar.add(Calendar.DAY_OF_YEAR, DRAW_OFFSET_DAYS);
+        return calendar.getTime();
+    }
+
+    public static ArrayList<String> toDeviceIdList(Object rawValue) {
+        ArrayList<String> deviceIds = new ArrayList<>();
+        if (!(rawValue instanceof List)) {
+            return deviceIds;
+        }
+
+        for (Object item : (List<?>) rawValue) {
+            if (item instanceof String) {
+                deviceIds.add((String) item);
+            } else if (item instanceof Map) {
+                Object deviceId = ((Map<?, ?>) item).get("deviceId");
+                if (deviceId instanceof String && !((String) deviceId).isEmpty()) {
+                    deviceIds.add((String) deviceId);
+                }
+            }
+        }
+
+        return deviceIds;
+    }
+}

--- a/CodeBase/app/src/main/java/com/example/codebase/FinalEntrantListAdapter.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/FinalEntrantListAdapter.java
@@ -12,8 +12,8 @@ import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 
-public class FinalEntrantListAdapter extends ArrayAdapter<Entrant> {
-    public FinalEntrantListAdapter(Context context, ArrayList<Entrant> entrants){
+public class FinalEntrantListAdapter extends ArrayAdapter<String> {
+    public FinalEntrantListAdapter(Context context, ArrayList<String> entrants){
         super(context, 0, entrants);
     }
 
@@ -26,13 +26,13 @@ public class FinalEntrantListAdapter extends ArrayAdapter<Entrant> {
         else
             view = convertView;
 
-        Entrant entrant = getItem(position);
+        String deviceId = getItem(position);
 
         TextView entrantName = view.findViewById(R.id.entrantNameTextView);
         TextView entrantEmail = view.findViewById(R.id.entrantEmailTextView);
 
-        entrantName.setText(entrant.getName());
-        entrantName.setText(entrant.getEmail());
+        entrantName.setText(deviceId != null ? deviceId : "");
+        entrantEmail.setText("");
 
         return view;
 

--- a/CodeBase/app/src/main/java/com/example/codebase/FinalEntrantListFragment.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/FinalEntrantListFragment.java
@@ -19,7 +19,6 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 
 import java.util.ArrayList;
-import java.util.List;
 
 //User story 02.06.03
 public class FinalEntrantListFragment extends Fragment {
@@ -38,7 +37,7 @@ public class FinalEntrantListFragment extends Fragment {
     ListView listView;
 
     Event event;
-    ArrayList<Entrant> finalEntrants;
+    ArrayList<String> finalEntrants;
     Long maxCapacity;
 
     FinalEntrantListAdapter entrantAdapter;
@@ -70,7 +69,10 @@ public class FinalEntrantListFragment extends Fragment {
         entrantAdapter = new FinalEntrantListAdapter(view.getContext(), finalEntrants);
         listView.setAdapter(entrantAdapter);
 
-        int percentageCap = (int)(finalEntrants.size()/maxCapacity*100);
+        int percentageCap = 0;
+        if (maxCapacity != null && maxCapacity > 0) {
+            percentageCap = (int) ((finalEntrants.size() * 100L) / maxCapacity);
+        }
         String capacityString = finalEntrants.size()+"/"+maxCapacity;
         String percentageString = Integer.toString(percentageCap)+"%";
 

--- a/CodeBase/app/src/main/java/com/example/codebase/InvitedEntrantsActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/InvitedEntrantsActivity.java
@@ -10,7 +10,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -26,7 +25,7 @@ import java.util.Map;
  *   All / Pending / Accepted / Declined
  *
  * US 02.06.04 — Cancel entrant (organizer action):
- *   Cancel button is only enabled once today >= eventStartDate.
+ *   Cancel button is only enabled once the registration deadline has passed.
  *   On confirm → remove from selectedEntrants, add to cancelledEntrants.
  *
  * Logic:
@@ -61,8 +60,8 @@ public class InvitedEntrantsActivity extends AppCompatActivity
     private String eventId;
     private String eventTitle;
 
-    // regClose loaded from Firestore — used to enable/disable cancel button
-    private Date regCloseDate = null;
+    // registration deadline loaded from Firestore — used to enable/disable cancel button
+    private Date registrationDeadlineDate = null;
 
     // Full lists
     private List<InvitedEntrant> allList     = new ArrayList<>();
@@ -137,17 +136,19 @@ public class InvitedEntrantsActivity extends AppCompatActivity
             return;
         }
 
-        // ── Read regClose ─────────────────────────────────────────────────────
-        Timestamp regCloseTs = doc.getTimestamp("regClose");
-        regCloseDate = (regCloseTs != null) ? regCloseTs.toDate() : null;
+        Event event = EventSchema.normalizeLoadedEvent(doc);
+        if (event == null) {
+            Toast.makeText(this, "Event not found", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
 
-        // Pass regClose to adapter so it can decide enabled/disabled per row
-        adapter.setRegCloseDate(regCloseDate);
+        registrationDeadlineDate = event.getRegistrationDeadline();
+        adapter.setRegistrationDeadlineDate(registrationDeadlineDate);
 
-        // ── Read arrays ───────────────────────────────────────────────────────
-        List<String> selected  = toStringList(doc.get("selectedEntrants"));
-        List<String> enrolled  = toStringList(doc.get("enrolledEntrants"));
-        List<String> cancelled = toStringList(doc.get("cancelledEntrants"));
+        List<String> selected = event.getSelectedEntrants();
+        List<String> enrolled = event.getEnrolledEntrants();
+        List<String> cancelled = event.getCancelledEntrants();
 
         // ── Calculate groups ──────────────────────────────────────────────────
 
@@ -285,19 +286,6 @@ public class InvitedEntrantsActivity extends AppCompatActivity
     }
 
     // ─── Helper ───────────────────────────────────────────────────────────────
-
-    @SuppressWarnings("unchecked")
-    private List<String> toStringList(Object obj) {
-        if (obj instanceof List) {
-            List<?> raw = (List<?>) obj;
-            List<String> result = new ArrayList<>();
-            for (Object item : raw) {
-                if (item instanceof String) result.add((String) item);
-            }
-            return result;
-        }
-        return new ArrayList<>();
-    }
 
     // ─── Model ────────────────────────────────────────────────────────────────
 

--- a/CodeBase/app/src/main/java/com/example/codebase/InvitedEntrantsAdapter.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/InvitedEntrantsAdapter.java
@@ -17,8 +17,8 @@ import java.util.List;
  *
  * Cancel button rules (US 02.06.04):
  *   - Only shown for Pending entrants
- *   - GREYED OUT (disabled) if today < eventStartDate  → entrant still has time
- *   - ENABLED (red)         if today >= eventStartDate → time is up
+ *   - GREYED OUT (disabled) if today < registration deadline  → entrant still has time
+ *   - ENABLED (red)         if today >= registration deadline → time is up
  *
  * On cancel press → calls CancelListener.onCancelRequested() back to Activity
  * which shows confirmation dialog and updates Firestore.
@@ -38,7 +38,7 @@ public class InvitedEntrantsAdapter extends
     private final CancelListener cancelListener;
 
     // Set by Activity after loading Firestore — determines button enabled state
-    private Date regCloseDate = null;
+    private Date registrationDeadlineDate = null;
 
     public InvitedEntrantsAdapter(
             List<InvitedEntrantsActivity.InvitedEntrant> list,
@@ -47,9 +47,9 @@ public class InvitedEntrantsAdapter extends
         this.cancelListener = cancelListener;
     }
 
-    /** Called by Activity once regClose is loaded from Firestore */
-    public void setRegCloseDate(Date regCloseDate) {
-        this.regCloseDate = regCloseDate;
+    /** Called by Activity once registration deadline is loaded from Firestore */
+    public void setRegistrationDeadlineDate(Date registrationDeadlineDate) {
+        this.registrationDeadlineDate = registrationDeadlineDate;
         notifyDataSetChanged();
     }
 
@@ -68,7 +68,7 @@ public class InvitedEntrantsAdapter extends
 
     @Override
     public void onBindViewHolder(@NonNull EntrantViewHolder holder, int position) {
-        holder.bind(list.get(position), regCloseDate, cancelListener);
+        holder.bind(list.get(position), registrationDeadlineDate, cancelListener);
     }
 
     @Override
@@ -91,8 +91,8 @@ public class InvitedEntrantsAdapter extends
 
         void bind(
                 InvitedEntrantsActivity.InvitedEntrant entrant,
-                Date regCloseDate,
-                CancelListener cancelListener) {
+                 Date registrationDeadlineDate,
+                 CancelListener cancelListener) {
 
             // ── Shortened deviceId ────────────────────────────────────────────
             String id = entrant.deviceId;
@@ -127,7 +127,7 @@ public class InvitedEntrantsAdapter extends
             btnCancel.setVisibility(View.VISIBLE);
 
             Date today = new Date();
-            boolean canCancel = regCloseDate != null && today.after(regCloseDate);
+            boolean canCancel = registrationDeadlineDate != null && today.after(registrationDeadlineDate);
 
             if (canCancel) {
                 // ── Enabled: event has started, time is up ────────────────────

--- a/CodeBase/app/src/main/java/com/example/codebase/NotificationsActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/NotificationsActivity.java
@@ -8,18 +8,12 @@ import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.google.firebase.firestore.DocumentSnapshot;
-import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.firestore.QuerySnapshot;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 
 /**
- * NotificationsActivity shows entrant notifications for:
- * - Selected
- * - Not Selected
+ * NotificationsActivity shows notifications stored in the notifications collection.
  *
  * Tapping a notification opens the related event details page.
  */
@@ -44,47 +38,29 @@ public class NotificationsActivity extends AppCompatActivity {
     }
 
     private void loadNotifications() {
-        FirebaseFirestore.getInstance()
-                .collection("events")
+        AppDatabase.getInstance()
+                .notificationsRef
+                .whereEqualTo("userId", deviceId)
                 .get()
-                .addOnSuccessListener(this::populateNotifications)
+                .addOnSuccessListener(queryDocumentSnapshots -> populateNotifications(queryDocumentSnapshots.getDocuments()))
                 .addOnFailureListener(e ->
                         Toast.makeText(this,
                                 "Failed to load notifications",
                                 Toast.LENGTH_SHORT).show());
     }
 
-    private void populateNotifications(QuerySnapshot snapshot) {
+    private void populateNotifications(java.util.List<DocumentSnapshot> documents) {
         items.clear();
         eventIds.clear();
 
-        for (DocumentSnapshot doc : snapshot.getDocuments()) {
-            String eventId = doc.getId();
-            String title = doc.getString("title");
-            if (title == null || title.isEmpty()) {
-                title = "Untitled Event";
-            }
-
-            Date drawDate = doc.getDate("drawDate");
-
-            List<?> selectedEntrants = (List<?>) doc.get("selectedEntrants");
-            List<?> enrolledEntrants = (List<?>) doc.get("enrolledEntrants");
-            List<?> waitingList = (List<?>) doc.get("waitingList");
-
-            boolean isSelected =
-                    listContainsDeviceId(selectedEntrants, deviceId) ||
-                            listContainsDeviceId(enrolledEntrants, deviceId);
-
-            boolean wasOnWaitlist = listContainsDeviceId(waitingList, deviceId);
-
-            if (isSelected) {
-                addNotification("Selected",
-                        "You were selected for " + title,
-                        eventId);
-            } else if (drawDate != null && new Date().after(drawDate) && wasOnWaitlist) {
-                addNotification("Not Selected",
-                        "You were not selected for " + title,
-                        eventId);
+        for (DocumentSnapshot doc : documents) {
+            AppNotification notification = doc.toObject(AppNotification.class);
+            if (notification != null && notification.getEventId() != null) {
+                addNotification(
+                        notification.getStatus() != null ? notification.getStatus() : "Notification",
+                        notification.getMessage() != null ? notification.getMessage() : "No message",
+                        notification.getEventId()
+                );
             }
         }
 
@@ -107,27 +83,4 @@ public class NotificationsActivity extends AppCompatActivity {
         eventIds.add(eventId);
     }
 
-    /**
-     * Checks whether a Firestore list contains the current device ID.
-     * Supports:
-     * - list of plain strings
-     * - list of maps with field "deviceId"
-     */
-    private boolean listContainsDeviceId(List<?> list, String deviceId) {
-        if (list == null) return false;
-
-        for (Object item : list) {
-            if (item instanceof String) {
-                if (deviceId.equals(item)) {
-                    return true;
-                }
-            } else if (item instanceof java.util.Map) {
-                Object mapDeviceId = ((java.util.Map<?, ?>) item).get("deviceId");
-                if (deviceId.equals(mapDeviceId)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
 }

--- a/CodeBase/app/src/main/java/com/example/codebase/OrganizerActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/OrganizerActivity.java
@@ -83,8 +83,7 @@ public class OrganizerActivity extends AppCompatActivity {
         });
 
         findViewById(R.id.navSearch).setOnClickListener(v -> {
-            startActivity(new Intent(this, BrowseEventsActivity.class));
-            finish();
+            Toast.makeText(this, "Not implemented yet", Toast.LENGTH_SHORT).show();
         });
 
         findViewById(R.id.navNotifications).setOnClickListener(v -> {
@@ -110,14 +109,8 @@ public class OrganizerActivity extends AppCompatActivity {
         eventList.clear();
 
         for (DocumentSnapshot doc : snapshot.getDocuments()) {
-            Event event = doc.toObject(Event.class);
+            Event event = EventSchema.normalizeLoadedEvent(doc);
             if (event != null) {
-                if (event.getId() == null || event.getId().isEmpty()) {
-                    event.setId(doc.getId());
-                }
-                if (event.getEventId() == null || event.getEventId().isEmpty()) {
-                    event.setEventId(doc.getId());
-                }
                 eventList.add(event);
             }
         }

--- a/CodeBase/app/src/main/java/com/example/codebase/OrganizerEventAdapter.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/OrganizerEventAdapter.java
@@ -8,8 +8,10 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * OrganizerEventAdapter — RecyclerView adapter for My Events screen.
@@ -115,6 +117,8 @@ public class OrganizerEventAdapter extends
     // ─── ViewHolder ───────────────────────────────────────────────────────────
 
     static class EventViewHolder extends RecyclerView.ViewHolder {
+        private static final SimpleDateFormat DATE_FORMAT =
+                new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
 
         private final TextView   tvTitle;
         private final TextView   tvDate;
@@ -135,7 +139,9 @@ public class OrganizerEventAdapter extends
 
         void bind(Event event, OnEventClickListener listener) {
             tvTitle.setText(event.getTitle());
-            tvDate.setText(event.getStartDate().toString());
+            tvDate.setText(event.getStartDate() != null
+                    ? DATE_FORMAT.format(event.getStartDate())
+                    : "Date: Not set");
 
             // ── Poster thumbnail ──────────────────────────────────────────────
             if (event.getPoster() != null && event.getPoster().getPosterImageBase64() != null && !event.getPoster().getPosterImageBase64().isEmpty()) {
@@ -153,10 +159,12 @@ public class OrganizerEventAdapter extends
                 ivThumbnail.setImageBitmap(null); // shows bg_event_thumbnail placeholder
             }
 
+            int waitlistCount = event.getWaitingList() != null ? event.getWaitingList().size() : 0;
+            int selectedCount = event.getSelectedEntrants() != null ? event.getSelectedEntrants().size() : 0;
             tvWaiting.setText(itemView.getContext()
-                    .getString(R.string.waitlist_count, event.getWaitingList().stream().count()));
+                    .getString(R.string.waitlist_count, waitlistCount));
             tvSelected.setText(itemView.getContext()
-                    .getString(R.string.drawn_count, event.getSelectedEntrants().stream().count()));
+                    .getString(R.string.drawn_count, selectedCount));
             tvSelected.setVisibility(View.VISIBLE);
 
             // ── Calculate and apply status badge ──────────────────────────────

--- a/CodeBase/app/src/main/java/com/example/codebase/ProfileActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/ProfileActivity.java
@@ -130,7 +130,7 @@ public class ProfileActivity extends AppCompatActivity {
                 startActivity(new Intent(this, BrowseEventsActivity.class)));
 
         findViewById(R.id.navSearch).setOnClickListener(v ->
-                startActivity(new Intent(this, BrowseEventsActivity.class)));
+                Toast.makeText(this, "Not implemented yet", Toast.LENGTH_SHORT).show());
 
         findViewById(R.id.navNotifications).setOnClickListener(v ->
                 startActivity(new Intent(this, NotificationsActivity.class)));

--- a/CodeBase/app/src/main/java/com/example/codebase/QRScannerActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/QRScannerActivity.java
@@ -2,11 +2,7 @@ package com.example.codebase;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.view.LayoutInflater;
-import android.view.View;
 import android.widget.Button;
-import android.widget.ImageView;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.OptIn;
@@ -22,7 +18,6 @@ import androidx.core.content.ContextCompat;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.mlkit.vision.barcode.BarcodeScannerOptions;
 import com.google.mlkit.vision.barcode.BarcodeScanner;
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions;
 import com.google.mlkit.vision.barcode.BarcodeScanning;
@@ -31,6 +26,7 @@ import com.google.mlkit.vision.common.InputImage;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class QRScannerActivity extends AppCompatActivity {
 
@@ -45,7 +41,10 @@ public class QRScannerActivity extends AppCompatActivity {
         setContentView(R.layout.activity_qr_scanner);
 
         Button cancelButton = findViewById(R.id.button_cancel);
-        PreviewView previewView = findViewById(R.id.previewView);
+        previewView = findViewById(R.id.previewView);
+        cameraExecutor = Executors.newSingleThreadExecutor();
+
+        cancelButton.setOnClickListener(v -> finish());
 
         startCamera();
     }
@@ -86,7 +85,7 @@ public class QRScannerActivity extends AppCompatActivity {
                 .document(eventId)
                 .get()
                 .addOnSuccessListener(documentSnapshot -> {
-                    CreateEventViewModel event = documentSnapshot.toObject(CreateEventViewModel.class);
+                    Event event = EventSchema.normalizeLoadedEvent(documentSnapshot);
                     if (event != null) {
                         showEventDialog(eventId, event);
                     } else {
@@ -96,7 +95,7 @@ public class QRScannerActivity extends AppCompatActivity {
                 });
     }
 
-    private void showEventDialog(String eventId, CreateEventViewModel event){
+    private void showEventDialog(String eventId, Event event){
 //        View dialogView = LayoutInflater.from(this).inflate(R.layout.dialog_qr_result, null);
 //        ImageView poster  = dialogView.findViewById(R.id.poster);
 //        TextView title = dialogView.findViewById(R.id.eventTitle);
@@ -139,12 +138,17 @@ public class QRScannerActivity extends AppCompatActivity {
                             });
                         }
                     }
-                });
+                    imageProxy.close();
+                })
+                .addOnFailureListener(e -> imageProxy.close())
+                .addOnCanceledListener(imageProxy::close);
     }
 
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        cameraExecutor.shutdown();
+        if (cameraExecutor != null) {
+            cameraExecutor.shutdown();
+        }
     }
 }

--- a/CodeBase/app/src/main/res/layout/activity_event_detail.xml
+++ b/CodeBase/app/src/main/res/layout/activity_event_detail.xml
@@ -90,7 +90,7 @@
                     android:layout_height="wrap_content"
                     android:textSize="22sp"
                     android:textStyle="bold"
-                    android:textColor="#111111"
+                    android:textColor="@android:color/white"
                     android:layout_marginBottom="6dp" />
 
                 <!-- Date row -->
@@ -114,7 +114,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:textSize="13sp"
-                        android:textColor="#555555" />
+                        android:textColor="@android:color/white" />
 
                 </LinearLayout>
 
@@ -138,7 +138,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:textSize="13sp"
-                        android:textColor="#555555" />
+                        android:textColor="@android:color/white" />
 
                 </LinearLayout>
 
@@ -156,7 +156,7 @@
             android:paddingTop="12dp"
             android:paddingBottom="4dp"
             android:textSize="13sp"
-            android:textColor="#555555"
+            android:textColor="@color/textSecondary"
             android:lineSpacingMultiplier="1.4" />
 
         <!-- ── CAPACITY ROW ──────────────────────────────────────────────── -->
@@ -168,6 +168,28 @@
             android:paddingEnd="20dp"
             android:paddingTop="8dp"
             android:paddingBottom="8dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/cost_label"
+                    android:textSize="11sp"
+                    android:textColor="#AAAAAA"
+                    android:textAllCaps="true" />
+                <TextView
+                    android:id="@+id/tvEventCost"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="$0.00"
+                    android:textSize="18sp"
+                    android:textStyle="bold"
+                    android:textColor="#111111" />
+            </LinearLayout>
 
             <LinearLayout
                 android:layout_width="0dp"
@@ -199,7 +221,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/winners_count_label"
+                    android:text="@string/waitlist_capacity_label"
                     android:textSize="11sp"
                     android:textColor="#AAAAAA"
                     android:textAllCaps="true" />

--- a/CodeBase/app/src/main/res/layout/activity_organizer.xml
+++ b/CodeBase/app/src/main/res/layout/activity_organizer.xml
@@ -65,126 +65,161 @@
         app:backgroundTint="@color/primaryAccent"
         app:tint="@color/white" />
 
-    <!-- Bottom navigation -->
-    <LinearLayout
+    <com.google.android.material.card.MaterialCardView
         android:layout_width="match_parent"
-        android:layout_height="64dp"
+        android:layout_height="72dp"
         android:layout_gravity="bottom"
-        android:orientation="horizontal"
-        android:background="#FFFFFF"
-        android:elevation="4dp"
-        android:baselineAligned="false">
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginBottom="20dp"
+        app:cardCornerRadius="22dp"
+        app:cardElevation="2dp"
+        app:cardBackgroundColor="@color/surface"
+        app:strokeWidth="1dp"
+        app:strokeColor="@color/border">
 
-        <!-- Explore -->
         <LinearLayout
-            android:id="@+id/navExplore"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:gravity="center"
-            android:clickable="true"
-            android:focusable="true">
-            <ImageView
-                android:layout_width="22dp"
-                android:layout_height="22dp"
-                android:src="@android:drawable/ic_menu_compass"
-                app:tint="#CCCCCC"
-                android:contentDescription="@string/nav_explore" />
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/nav_explore"
-                android:textSize="12sp"
-                android:textColor="#CCCCCC" />
+            android:orientation="horizontal">
+
+            <LinearLayout
+                android:id="@+id/navExplore"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:clickable="true"
+                android:focusable="true"
+                android:baselineAligned="false">
+                <ImageView
+                    android:layout_width="22dp"
+                    android:layout_height="22dp"
+                    android:src="@drawable/ic_nav_explore"
+                    app:tint="@color/textDisabled"
+                    android:contentDescription="@string/nav_explore" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/nav_explore"
+                    android:textSize="9sp"
+                    android:fontFamily="sans-serif-medium"
+                    android:textColor="@color/textDisabled"
+                    android:layout_marginTop="2dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/navSearch"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:clickable="true"
+                android:focusable="true"
+                android:baselineAligned="false">
+                <ImageView
+                    android:layout_width="22dp"
+                    android:layout_height="22dp"
+                    android:src="@drawable/ic_nav_search"
+                    app:tint="@color/textDisabled"
+                    android:contentDescription="@string/nav_search" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/nav_search"
+                    android:textSize="9sp"
+                    android:fontFamily="sans-serif-medium"
+                    android:textColor="@color/textDisabled"
+                    android:layout_marginTop="2dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/navMyEvents"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:clickable="true"
+                android:focusable="true"
+                android:baselineAligned="false">
+                <FrameLayout
+                    android:layout_width="48dp"
+                    android:layout_height="32dp"
+                    android:background="@drawable/bg_role_icon_blue"
+                    android:backgroundTint="@color/accentTint">
+                    <ImageView
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:layout_gravity="center"
+                        android:src="@drawable/ic_nav_events"
+                        app:tint="@color/primaryAccent"
+                        android:contentDescription="@string/nav_my_events" />
+                </FrameLayout>
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/nav_my_events"
+                    android:textSize="9sp"
+                    android:fontFamily="sans-serif-medium"
+                    android:textColor="@color/primaryAccent"
+                    android:layout_marginTop="2dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/navNotifications"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:clickable="true"
+                android:focusable="true"
+                android:baselineAligned="false">
+                <ImageView
+                    android:layout_width="22dp"
+                    android:layout_height="22dp"
+                    android:src="@drawable/ic_nav_notifications"
+                    app:tint="@color/textDisabled"
+                    android:contentDescription="@string/nav_notifications" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/nav_notifications"
+                    android:textSize="9sp"
+                    android:fontFamily="sans-serif-medium"
+                    android:textColor="@color/textDisabled"
+                    android:layout_marginTop="2dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/navProfile"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:clickable="true"
+                android:focusable="true"
+                android:baselineAligned="false">
+                <ImageView
+                    android:layout_width="22dp"
+                    android:layout_height="22dp"
+                    android:src="@drawable/ic_nav_profile"
+                    app:tint="@color/textDisabled"
+                    android:contentDescription="@string/nav_profile" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/nav_profile"
+                    android:textSize="9sp"
+                    android:fontFamily="sans-serif-medium"
+                    android:textColor="@color/textDisabled"
+                    android:layout_marginTop="2dp" />
+            </LinearLayout>
+
         </LinearLayout>
-
-        <!-- Search -->
-        <LinearLayout
-            android:id="@+id/navSearch"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:gravity="center"
-            android:clickable="true"
-            android:focusable="true">
-            <ImageView
-                android:layout_width="22dp"
-                android:layout_height="22dp"
-                android:src="@android:drawable/ic_menu_search"
-                app:tint="#CCCCCC"
-                android:contentDescription="@string/nav_search" />
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/nav_search"
-                android:textSize="12sp"
-                android:textColor="#CCCCCC" />
-        </LinearLayout>
-
-        <!-- My Events -->
-        <LinearLayout
-            android:id="@+id/navMyEvents"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:gravity="center"
-            android:clickable="true"
-            android:focusable="true">
-            <ImageView
-                android:layout_width="22dp"
-                android:layout_height="22dp"
-                android:src="@android:drawable/ic_menu_agenda"
-                app:tint="#4A7A4A"
-                android:contentDescription="@string/nav_my_events" />
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/nav_my_events"
-                android:textSize="12sp"
-                android:textColor="#4A7A4A" />
-        </LinearLayout>
-
-        <!-- Notifications -->
-        <LinearLayout
-            android:id="@+id/navNotifications"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:gravity="center"
-            android:clickable="true"
-            android:focusable="true">
-            <ImageView
-                android:layout_width="22dp"
-                android:layout_height="22dp"
-                android:src="@android:drawable/ic_popup_reminder"
-                app:tint="#CCCCCC"
-                android:contentDescription="@string/nav_notifications" />
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/nav_notifications"
-                android:textSize="12sp"
-                android:textColor="#CCCCCC" />
-        </LinearLayout>
-
-        <!-- Profile -->
-        <TextView
-            android:id="@+id/navProfile"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:drawableTop="@android:drawable/ic_menu_myplaces"
-            android:drawableTint="#CCCCCC"
-            android:drawablePadding="2dp"
-            android:text="@string/nav_profile"
-            android:textSize="12sp"
-            android:textColor="#CCCCCC" />
-
-    </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/CodeBase/app/src/main/res/values/strings_organizer.xml
+++ b/CodeBase/app/src/main/res/values/strings_organizer.xml
@@ -69,8 +69,11 @@
 
     <!-- Event detail new fields -->
     <string name="date_not_set">Date not set</string>
+    <string name="cost_label">Cost</string>
     <string name="max_capacity_label">Max Capacity</string>
     <string name="winners_count_label">Winners Count</string>
+    <string name="waitlist_capacity_label">Waitlist Capacity</string>
+    <string name="not_applicable_short">N/A</string>
 
     <!-- Errors -->
     <string name="error_loading_event_detail">Failed to load event details</string>


### PR DESCRIPTION
## Summary

  This PR normalizes the app’s Firestore event schema and updates organizer-facing
  screens to use the same backend field names and data shapes consistently. It also
  cleans up several UI issues in the organizer flow, improves the event detail
  screen, and aligns navigation behavior across screens.

  ## Backend and data model changes

  - Normalized event reads/writes around the canonical Firestore fields:
      - startDate
      - endDate
      - registrationOpen
      - registrationDeadline
      - drawDate
      - maxCapacity
      - waitlistCap
  - Added EventSchema as a central normalization layer for loaded event documents.
  - Kept id and eventId synchronized for compatibility.
  - Standardized event participant lists to use device ID string arrays
    consistently.
  - Updated event creation/edit flows to persist the normalized schema.
  - Fixed mismatches between older legacy field names and the current schema across
    organizer/event flows.

  ## Notifications

  - Switched the notifications tab to read from the dedicated Firestore
    notifications collection.
  - Kept support for notification display and unread-check behavior through the
    existing AppNotification model and notification checker flow.
  - Removed the previous event-derived notification behavior from the notifications
    screen so the tab is backed by one schema source.

  ## Organizer and event detail UI

  - Fixed event detail values so:
      - max capacity shows event capacity
      - waitlist capacity shows the waitlist limit
      - cost is now displayed alongside those values
  - Updated the event detail date display to show a clean start/end date range
    without time.
  - Fixed text color issues in the event detail hero/content sections for
    readability.
  - Updated the organizer bottom navigation to match the profile screen’s nav style
    and layout.
  - Changed the Search tab behavior to show a Not implemented yet toast instead of
    routing to browse events.

  ## Miscellaneous

  - Added CodeBase/.gradle-user-home/ to .gitignore to avoid tracking local Gradle
    cache data.
  - Included related cleanup and consistency updates across organizer, invited/
    cancelled entrant, QR, and event repository code paths.