### PR TITLE
Merge entrant invitation flow and expose waiting list actions in active navigation from origin/Karan

### DIFF
--- a/CodeBase/app/src/main/AndroidManifest.xml
+++ b/CodeBase/app/src/main/AndroidManifest.xml
@@ -17,6 +17,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.CodeBase">
+        <activity android:name=".ExplorePageActivity" android:exported="false" />
+        <activity android:name=".InvitationsActivity" android:exported="false" />
+        <activity android:name=".EntrantEventDetailActivity" android:exported="false" />
 
         <activity
             android:name=".NotificationsActivity"

--- a/CodeBase/app/src/main/java/com/example/codebase/BrowseEventsActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/BrowseEventsActivity.java
@@ -20,6 +20,7 @@ public class BrowseEventsActivity extends AppCompatActivity {
 
     private RecyclerView recyclerViewEvents;
     private TextView textViewEmptyState;
+    private String deviceId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -28,6 +29,7 @@ public class BrowseEventsActivity extends AppCompatActivity {
 
         recyclerViewEvents = findViewById(R.id.recyclerViewEvents);
         textViewEmptyState = findViewById(R.id.textViewEmptyState);
+        deviceId = DeviceIdManager.getOrCreateDeviceId(this);
 
         recyclerViewEvents.setLayoutManager(new LinearLayoutManager(this));
 
@@ -65,8 +67,15 @@ public class BrowseEventsActivity extends AppCompatActivity {
         recyclerViewEvents.setVisibility(View.VISIBLE);
 
         EventAdapter adapter = new EventAdapter(events, event -> {
-            Intent intent = new Intent(BrowseEventsActivity.this, EventDetailsActivity.class);
-            intent.putExtra("eventId", event.getEventId());
+            Intent intent;
+            if (deviceId.equals(event.getOrganizerDeviceId())) {
+                intent = new Intent(BrowseEventsActivity.this, EventDetailActivity.class);
+                intent.putExtra(EventDetailActivity.EXTRA_EVENT_ID, event.getEventId());
+                intent.putExtra(EventDetailActivity.EXTRA_EVENT_TITLE, event.getTitle());
+            } else {
+                intent = new Intent(BrowseEventsActivity.this, EntrantEventDetailActivity.class);
+                intent.putExtra(EntrantEventDetailActivity.EXTRA_EVENT_ID, event.getEventId());
+            }
             startActivity(intent);
         });
 

--- a/CodeBase/app/src/main/java/com/example/codebase/EntrantEventDetailActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/EntrantEventDetailActivity.java
@@ -1,0 +1,212 @@
+package com.example.codebase;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FieldValue;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Locale;
+
+public class EntrantEventDetailActivity extends AppCompatActivity {
+
+    public static final String EXTRA_EVENT_ID = "event_id";
+
+    private String eventId;
+    private String deviceId;
+    private Event event;
+
+    private TextView tvTitle, tvDate, tvLocation, tvDescription;
+    private ImageView ivPoster;
+    private Button btnJoin, btnLeave, btnDropOut;
+    private View layoutJoinLeave;
+    private View progressBar;
+
+    private final SimpleDateFormat displayFormat = new SimpleDateFormat("MMM dd, yyyy · HH:mm", Locale.getDefault());
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_entrant_event_detail);
+
+        eventId = getIntent().getStringExtra(EXTRA_EVENT_ID);
+        deviceId = DeviceIdManager.getOrCreateDeviceId(this);
+
+        tvTitle = findViewById(R.id.tvEntrantEventTitle);
+        tvDate = findViewById(R.id.tvEntrantEventDate);
+        tvLocation = findViewById(R.id.tvEntrantEventLocation);
+        tvDescription = findViewById(R.id.tvEntrantEventDescription);
+        ivPoster = findViewById(R.id.ivEntrantHeroPoster);
+        btnJoin = findViewById(R.id.btnJoinWaitingList);
+        btnLeave = findViewById(R.id.btnLeaveWaitingList);
+        btnDropOut = findViewById(R.id.btnDropOut);
+        layoutJoinLeave = findViewById(R.id.layoutJoinLeave);
+        progressBar = findViewById(R.id.entrantDetailProgressBar);
+
+        findViewById(R.id.btnEntrantBack).setOnClickListener(v -> finish());
+
+        btnJoin.setOnClickListener(v -> showJoinConfirmation());
+        btnLeave.setOnClickListener(v -> showLeaveConfirmation());
+        btnDropOut.setOnClickListener(v -> showDropOutConfirmation());
+
+        loadEventDetails();
+    }
+
+    private void loadEventDetails() {
+        progressBar.setVisibility(View.VISIBLE);
+        FirebaseFirestore.getInstance().collection("events").document(eventId)
+                .get()
+                .addOnSuccessListener(this::onEventLoaded)
+                .addOnFailureListener(e -> {
+                    progressBar.setVisibility(View.GONE);
+                    Toast.makeText(this, "Error loading event", Toast.LENGTH_SHORT).show();
+                });
+    }
+
+    private void onEventLoaded(DocumentSnapshot doc) {
+        progressBar.setVisibility(View.GONE);
+        event = doc.toObject(Event.class);
+        if (event == null) return;
+
+        tvTitle.setText(event.getTitle());
+        tvLocation.setText(event.getLocation());
+        tvDescription.setText(event.getDescription());
+
+        if (event.getStartDate() != null) {
+            tvDate.setText(displayFormat.format(event.getStartDate()));
+        }
+
+        if (event.getPoster() != null && event.getPoster().getPosterImageBase64() != null) {
+            ivPoster.setImageBitmap(EventPoster.decodeImage(event.getPoster().getPosterImageBase64()));
+        }
+
+        updateButtonStates();
+    }
+
+    private void updateButtonStates() {
+        if (event == null) return;
+
+        ArrayList<String> enrolled = event.getEnrolledEntrants();
+        boolean isEnrolled = enrolled != null && enrolled.contains(deviceId);
+
+        if (isEnrolled) {
+            // User has accepted invitation
+            btnDropOut.setVisibility(View.VISIBLE);
+            layoutJoinLeave.setVisibility(View.GONE);
+        } else {
+            // User is not enrolled
+            btnDropOut.setVisibility(View.GONE);
+            layoutJoinLeave.setVisibility(View.VISIBLE);
+
+            ArrayList<String> waitingList = event.getWaitingList();
+            boolean isWaiting = waitingList != null && waitingList.contains(deviceId);
+
+            if (isWaiting) {
+                btnJoin.setEnabled(false);
+                btnJoin.setAlpha(0.5f);
+                btnLeave.setEnabled(true);
+                btnLeave.setAlpha(1.0f);
+            } else {
+                // Check if registration is still open to allow joining
+                boolean isRegOpen = true;
+                if (event.getRegistrationDeadline() != null) {
+                    isRegOpen = new Date().before(event.getRegistrationDeadline());
+                }
+
+                if (isRegOpen) {
+                    btnJoin.setEnabled(true);
+                    btnJoin.setAlpha(1.0f);
+                } else {
+                    btnJoin.setEnabled(false);
+                    btnJoin.setAlpha(0.5f);
+                }
+                btnLeave.setEnabled(false);
+                btnLeave.setAlpha(0.5f);
+            }
+        }
+    }
+
+    private void showJoinConfirmation() {
+        new AlertDialog.Builder(this)
+                .setTitle("Join Waiting List")
+                .setMessage("Would you like to join the waiting list for this event?")
+                .setPositiveButton("Confirm", (dialog, which) -> joinWaitingList())
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private void showLeaveConfirmation() {
+        new AlertDialog.Builder(this)
+                .setTitle("Leave Waiting List")
+                .setMessage("Are you sure you want to leave the waiting list?")
+                .setPositiveButton("Confirm", (dialog, which) -> leaveWaitingList())
+                .setNegativeButton("Stay in list", null)
+                .show();
+    }
+
+    private void showDropOutConfirmation() {
+        new AlertDialog.Builder(this)
+                .setTitle("Drop Out of Event")
+                .setMessage("Are you sure you want to drop out of this event?")
+                .setPositiveButton("Confirm", (dialog, which) -> dropOutOfEvent())
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private void joinWaitingList() {
+        progressBar.setVisibility(View.VISIBLE);
+        FirebaseFirestore.getInstance().collection("events").document(eventId)
+                .update("waitingList", FieldValue.arrayUnion(deviceId))
+                .addOnSuccessListener(aVoid -> {
+                    Toast.makeText(this, "Joined waiting list!", Toast.LENGTH_SHORT).show();
+                    loadEventDetails();
+                })
+                .addOnFailureListener(e -> {
+                    progressBar.setVisibility(View.GONE);
+                    Toast.makeText(this, "Failed to join", Toast.LENGTH_SHORT).show();
+                });
+    }
+
+    private void leaveWaitingList() {
+        progressBar.setVisibility(View.VISIBLE);
+        FirebaseFirestore.getInstance().collection("events").document(eventId)
+                .update("waitingList", FieldValue.arrayRemove(deviceId))
+                .addOnSuccessListener(aVoid -> {
+                    Toast.makeText(this, "Left waiting list.", Toast.LENGTH_SHORT).show();
+                    loadEventDetails();
+                })
+                .addOnFailureListener(e -> {
+                    progressBar.setVisibility(View.GONE);
+                    Toast.makeText(this, "Failed to leave", Toast.LENGTH_SHORT).show();
+                });
+    }
+
+    private void dropOutOfEvent() {
+        progressBar.setVisibility(View.VISIBLE);
+        // Remove from enrolledEntrants and add to cancelledEntrants
+        FirebaseFirestore.getInstance().collection("events").document(eventId)
+                .update(
+                        "enrolledEntrants", FieldValue.arrayRemove(deviceId),
+                        "cancelledEntrants", FieldValue.arrayUnion(deviceId)
+                )
+                .addOnSuccessListener(aVoid -> {
+                    Toast.makeText(this, "Dropped out of event.", Toast.LENGTH_SHORT).show();
+                    loadEventDetails();
+                })
+                .addOnFailureListener(e -> {
+                    progressBar.setVisibility(View.GONE);
+                    Toast.makeText(this, "Failed to drop out", Toast.LENGTH_SHORT).show();
+                });
+    }
+}

--- a/CodeBase/app/src/main/java/com/example/codebase/EventDetailActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/EventDetailActivity.java
@@ -18,19 +18,7 @@ import java.util.List;
 import java.util.Locale;
 
 /**
- * EventDetailActivity — Event detail screen for Organizer role.
- *
- * Reads canonical event fields from Firestore:
- *   title, description, location
- *   startDate, endDate, registrationOpen, registrationDeadline, drawDate
- *   maxCapacity, waitlistCap
- *   waitingList, selectedEntrants, enrolledEntrants, cancelledEntrants
- *
- * Status badge is calculated in real time from dates + arrays.
- * Firestore status field is NOT used.
- *
- * Add to AndroidManifest.xml:
- *   <activity android:name=".EventDetailActivity" android:exported="false" />
+ * Event detail screen for organizer role.
  */
 public class EventDetailActivity extends AppCompatActivity {
 
@@ -56,13 +44,11 @@ public class EventDetailActivity extends AppCompatActivity {
     private android.widget.ImageView ivHeroPoster;
     private View progressBar;
     private Event event;
+
     private final SimpleDateFormat displayDateFormat =
             new SimpleDateFormat("MMM dd, yyyy", Locale.getDefault());
     private final NumberFormat currencyFormat =
             NumberFormat.getCurrencyInstance(Locale.getDefault());
-
-    private final SimpleDateFormat displayFormat =
-            new SimpleDateFormat("MMM dd, yyyy · HH:mm", Locale.getDefault());
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -72,7 +58,6 @@ public class EventDetailActivity extends AppCompatActivity {
         eventId = getIntent().getStringExtra(EXTRA_EVENT_ID);
         eventTitle = getIntent().getStringExtra(EXTRA_EVENT_TITLE);
 
-        // ── Bind views ────────────────────────────────────────────────────────
         tvDetailTitle = findViewById(R.id.tvDetailTitle);
         tvDetailDate = findViewById(R.id.tvDetailDate);
         tvDetailLocation = findViewById(R.id.tvDetailLocation);
@@ -89,10 +74,8 @@ public class EventDetailActivity extends AppCompatActivity {
         ivHeroPoster = findViewById(R.id.ivHeroPoster);
         progressBar = findViewById(R.id.detailProgressBar);
 
-        // ── Back button ───────────────────────────────────────────────────────
         findViewById(R.id.btnBack).setOnClickListener(v -> finish());
 
-        // ── Invited stat card → InvitedEntrantsActivity ───────────────────────
         findViewById(R.id.cardInvited).setOnClickListener(v -> {
             Intent intent = new Intent(this, InvitedEntrantsActivity.class);
             intent.putExtra(InvitedEntrantsActivity.EXTRA_EVENT_ID, eventId);
@@ -100,7 +83,6 @@ public class EventDetailActivity extends AppCompatActivity {
             startActivity(intent);
         });
 
-        // ── LOTTERY MANAGEMENT ────────────────────────────────────────────────
         findViewById(R.id.rowRunLottery).setOnClickListener(v ->
                 Toast.makeText(this,
                         getString(R.string.lottery_draw_coming_soon),
@@ -112,7 +94,6 @@ public class EventDetailActivity extends AppCompatActivity {
                         Toast.LENGTH_SHORT).show()
         );
 
-        // ── EVENT DATA ────────────────────────────────────────────────────────
         findViewById(R.id.rowViewWaitingList).setOnClickListener(v ->
                 Toast.makeText(this,
                         getString(R.string.view_waiting_list_coming_soon),
@@ -129,7 +110,6 @@ public class EventDetailActivity extends AppCompatActivity {
             startActivity(intent);
         });
 
-        // ── SETTINGS ─────────────────────────────────────────────────────────
         findViewById(R.id.rowEditEvent).setOnClickListener(v -> {
             if (event == null) {
                 Toast.makeText(this, "Event not loaded yet", Toast.LENGTH_SHORT).show();
@@ -153,20 +133,19 @@ public class EventDetailActivity extends AppCompatActivity {
             if (event.getStartDate() != null) {
                 intent.putExtra("startDate", sdf.format(event.getStartDate()));
             }
-
-            if (event.getEndDate() != null)
+            if (event.getEndDate() != null) {
                 intent.putExtra("endDate", sdf.format(event.getEndDate()));
-
-            if (event.getRegistrationOpen() != null)
+            }
+            if (event.getRegistrationOpen() != null) {
                 intent.putExtra("registrationOpen", sdf.format(event.getRegistrationOpen()));
-
-            if (event.getRegistrationDeadline() != null)
+            }
+            if (event.getRegistrationDeadline() != null) {
                 intent.putExtra("registrationDeadline", sdf.format(event.getRegistrationDeadline()));
+            }
 
             startActivity(intent);
         });
 
-        // Cancelled stat card
         findViewById(R.id.cardCancelled).setOnClickListener(v -> {
             Intent intent = new Intent(this, CancelledEntrantsActivity.class);
             intent.putExtra(CancelledEntrantsActivity.EXTRA_EVENT_ID, eventId);
@@ -174,7 +153,6 @@ public class EventDetailActivity extends AppCompatActivity {
             startActivity(intent);
         });
 
-        // View Cancelled Users row
         findViewById(R.id.rowCancelledUsers).setOnClickListener(v -> {
             Intent intent = new Intent(this, CancelledEntrantsActivity.class);
             intent.putExtra(CancelledEntrantsActivity.EXTRA_EVENT_ID, eventId);
@@ -184,8 +162,6 @@ public class EventDetailActivity extends AppCompatActivity {
 
         loadEventDetails();
     }
-
-    // ─── Load event from Firestore ────────────────────────────────────────────
 
     private void loadEventDetails() {
         progressBar.setVisibility(View.VISIBLE);
@@ -223,7 +199,6 @@ public class EventDetailActivity extends AppCompatActivity {
             return;
         }
 
-        // ── Poster image — stored as Base64 string in Firestore ──────────────
         if (event.getPoster() != null
                 && event.getPoster().getPosterImageBase64() != null
                 && !event.getPoster().getPosterImageBase64().isEmpty()) {
@@ -242,7 +217,6 @@ public class EventDetailActivity extends AppCompatActivity {
             ivHeroPoster.setBackgroundResource(R.drawable.bg_hero_image);
         }
 
-        // ── Basic fields ──────────────────────────────────────────────────────
         eventTitle = event.getTitle() != null
                 ? event.getTitle() : getString(R.string.untitled_event);
         String location = event.getLocation() != null ? event.getLocation() : "";
@@ -252,42 +226,26 @@ public class EventDetailActivity extends AppCompatActivity {
         tvDetailLocation.setText(location);
         tvDetailDescription.setText(description);
 
-        // ── Timestamps ────────────────────────────────────────────────────────
-        // ── Misc fields ───────────────────────────────────────────────────────
-        Boolean geoEnabled = event.isGeoEnabled(); // reserved for future use
-
-        // ── Timestamps ────────────────────────────────────────────────────────
-        Date regOpen = event.getRegistrationOpen() != null ? event.getRegistrationOpen() : null;
-        Date registrationDeadline = event.getRegistrationDeadline() != null ? event.getRegistrationDeadline() : null;
-        Date drawDate = event.getDrawDate() != null ? event.getDrawDate() : null;
-        Date startDate = event.getStartDate() != null ? event.getStartDate()  : null;
-        Date endDate = event.getEndDate() != null ? event.getEndDate() : null;
+        Date regOpen = event.getRegistrationOpen();
+        Date registrationDeadline = event.getRegistrationDeadline();
+        Date drawDate = event.getDrawDate();
+        Date startDate = event.getStartDate();
+        Date endDate = event.getEndDate();
 
         tvDetailDate.setText(formatEventDateRange(startDate, endDate));
 
-        // ── Capacity fields ───────────────────────────────────────────────────
         Long maxCapacity = event.getMaxCapacity();
         int waitlistCap = event.getWaitlistCap();
         float price = event.getPrice();
 
-        if (tvEventCost != null) {
-            tvEventCost.setText(currencyFormat.format(price));
-        }
+        tvEventCost.setText(currencyFormat.format(price));
+        tvMaxCapacity.setText((maxCapacity != null && maxCapacity > 0)
+                ? String.valueOf(maxCapacity)
+                : getString(R.string.not_applicable_short));
+        tvWinnersCount.setText(waitlistCap > 0
+                ? String.valueOf(waitlistCap)
+                : getString(R.string.not_applicable_short));
 
-        if (tvMaxCapacity != null) {
-            tvMaxCapacity.setText((maxCapacity != null && maxCapacity > 0)
-                    ? String.valueOf(maxCapacity) : "—");
-        }
-        if (tvMaxCapacity != null && (maxCapacity == null || maxCapacity <= 0)) {
-            tvMaxCapacity.setText(getString(R.string.not_applicable_short));
-        }
-        if (tvWinnersCount != null) {
-            tvWinnersCount.setText(waitlistCap > 0
-                    ? String.valueOf(waitlistCap)
-                    : getString(R.string.not_applicable_short));
-        }
-
-        // ── Arrays ────────────────────────────────────────────────────────────
         List<String> waitingList = event.getWaitingList();
         List<String> selectedEntrants = event.getSelectedEntrants();
         List<String> enrolledEntrants = event.getEnrolledEntrants();
@@ -304,7 +262,6 @@ public class EventDetailActivity extends AppCompatActivity {
         tvCancelledCount.setText(String.valueOf(cancelledCount));
         tvWaitingListRowCount.setText(String.valueOf(waitingCount));
 
-        // ── Status badge — calculated from dates + arrays ─────────────────────
         String status = calculateStatus(
                 regOpen, registrationDeadline, drawDate, startDate, endDate,
                 selectedEntrants, enrolledEntrants
@@ -312,18 +269,15 @@ public class EventDetailActivity extends AppCompatActivity {
         applyStatusBadge(status);
     }
 
-    // ─── Status calculation ───────────────────────────────────────────────────
-
     private String calculateStatus(
             Date regOpen,
             Date registrationDeadline,
             Date drawDate,
             Date startDate,
             Date endDate,
-            List<?> selectedEntrants,
-            List<?> enrolledEntrants) {
+            List<String> selectedEntrants,
+            List<String> enrolledEntrants) {
 
-        // Any null date → Draft
         if (regOpen == null || registrationDeadline == null || drawDate == null
                 || startDate == null || endDate == null) {
             return "Draft";
@@ -334,40 +288,27 @@ public class EventDetailActivity extends AppCompatActivity {
         boolean enrolledEmpty = enrolledEntrants == null || enrolledEntrants.isEmpty();
 
         if (today.before(regOpen)) {
-            // today < regOpen
             return "Registration Opening Soon";
-
         } else if (!today.before(regOpen) && !today.after(registrationDeadline)) {
-            // today >= regOpen AND today <= regClose
             return "Registration Open";
-
         } else if (today.after(registrationDeadline)
                 && today.before(drawDate)
                 && selectedEmpty) {
-            // today > regClose AND today < drawDate AND no winners yet
             return "Registration Closed / Lottery Opening Soon";
-
         } else if (today.after(drawDate)
                 && today.before(startDate)
                 && !selectedEmpty) {
-            // today > drawDate AND today < eventStart AND winners selected
             return "Lottery Closed & Event Scheduled";
-
         } else if (!today.before(startDate)
                 && !today.after(endDate)
                 && !enrolledEmpty) {
-            // today >= eventStart AND today <= eventEnd AND people enrolled
             return "In Progress";
-
         } else if (today.after(endDate)) {
             return "Event Ended";
-
         } else {
             return "Draft";
         }
     }
-
-    // ─── Apply status badge color + text ─────────────────────────────────────
 
     private String formatEventDateRange(Date startDate, Date endDate) {
         if (startDate == null) {
@@ -415,7 +356,7 @@ public class EventDetailActivity extends AppCompatActivity {
                 tvStatusBadge.setBackgroundResource(R.drawable.bg_pill_red);
                 tvStatusBadge.setTextColor(0xFF8B3A3A);
                 break;
-            default: // Draft
+            default:
                 tvStatusBadge.setBackgroundResource(R.drawable.bg_pill_amber);
                 tvStatusBadge.setTextColor(0xFF8B7A2A);
                 break;

--- a/CodeBase/app/src/main/java/com/example/codebase/ExploreEventAdapter.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/ExploreEventAdapter.java
@@ -1,0 +1,75 @@
+package com.example.codebase;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.List;
+
+/**
+ * ExploreEventAdapter — RecyclerView adapter for the ExplorePageActivity.
+ * Displays invitations to an Entrant and handles Accept/Decline actions.
+ */
+public class ExploreEventAdapter extends RecyclerView.Adapter<ExploreEventAdapter.ExploreViewHolder> {
+
+    // Interface to pass button clicks back to the Activity
+    public interface OnInvitationActionListener {
+        void onAcceptClick(Event event);
+        void onDeclineClick(Event event);
+        void onCardClick(Event event);
+    }
+
+    private final List<Event> invitationList;
+    private final OnInvitationActionListener listener;
+
+    public ExploreEventAdapter(List<Event> invitationList, OnInvitationActionListener listener) {
+        this.invitationList = invitationList;
+        this.listener = listener;
+    }
+
+    @NonNull
+    @Override
+    public ExploreViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.item_explore_event, parent, false);
+        return new ExploreViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ExploreViewHolder holder, int position) {
+        Event event = invitationList.get(position);
+
+        // Bind data to the views (Assume Event has these getters based on EventDetailActivity)
+        holder.tvEventTitle.setText(event.getTitle() != null ? event.getTitle() : "Untitled Event");
+
+        // Handle Action Buttons
+        holder.btnAccept.setOnClickListener(v -> listener.onAcceptClick(event));
+        holder.btnDecline.setOnClickListener(v -> listener.onDeclineClick(event));
+
+        // Handle clicking the whole card to see details
+        holder.itemView.setOnClickListener(v -> listener.onCardClick(event));
+    }
+
+    @Override
+    public int getItemCount() {
+        return invitationList.size();
+    }
+
+    static class ExploreViewHolder extends RecyclerView.ViewHolder {
+        TextView tvEventTitle;
+        Button btnAccept;
+        Button btnDecline;
+
+        public ExploreViewHolder(@NonNull View itemView) {
+            super(itemView);
+            tvEventTitle = itemView.findViewById(R.id.tvExploreEventTitle);
+            btnAccept = itemView.findViewById(R.id.btnExploreAccept);
+            btnDecline = itemView.findViewById(R.id.btnExploreDecline);
+        }
+    }
+}

--- a/CodeBase/app/src/main/java/com/example/codebase/ExplorePageActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/ExplorePageActivity.java
@@ -1,0 +1,139 @@
+package com.example.codebase;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * ExplorePageActivity — Displays all available events and a summary card for invitations.
+ */
+public class ExplorePageActivity extends AppCompatActivity {
+
+    private RecyclerView rvAllEvents;
+    private TextView tvNoEvents;
+    private View progressBar;
+    private View layoutInvitationCard;
+    private TextView tvInvitationCountSummary;
+
+    private OrganizerEventAdapter adapter; // Reusing OrganizerEventAdapter for event list
+    private List<Event> allEventsList = new ArrayList<>();
+    private String deviceId;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_explore_page);
+
+        deviceId = DeviceIdManager.getOrCreateDeviceId(this);
+
+        rvAllEvents = findViewById(R.id.rvAllEvents);
+        tvNoEvents = findViewById(R.id.tvNoEventsExplore);
+        progressBar = findViewById(R.id.exploreProgressBar);
+        layoutInvitationCard = findViewById(R.id.layoutInvitationCard);
+        tvInvitationCountSummary = findViewById(R.id.tvInvitationCountSummary);
+
+        findViewById(R.id.btnBackExplore).setOnClickListener(v -> finish());
+
+        // Setup Invitation Card Click
+        layoutInvitationCard.setOnClickListener(v -> {
+            startActivity(new Intent(ExplorePageActivity.this, InvitationsActivity.class));
+        });
+
+        // Setup All Events RecyclerView
+        rvAllEvents.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new OrganizerEventAdapter(allEventsList, event -> {
+            // Check if user is the organizer
+            if (deviceId.equals(event.getOrganizerDeviceId())) {
+                // Redirect to Organizer Detail page (with editing privileges)
+                Intent intent = new Intent(ExplorePageActivity.this, EventDetailActivity.class);
+                intent.putExtra(EventDetailActivity.EXTRA_EVENT_ID, event.getId());
+                intent.putExtra(EventDetailActivity.EXTRA_EVENT_TITLE, event.getTitle());
+                startActivity(intent);
+            } else {
+                // Entrants see a read-only detail page with Join/Leave Waiting List buttons
+                Intent intent = new Intent(ExplorePageActivity.this, EntrantEventDetailActivity.class);
+                intent.putExtra(EntrantEventDetailActivity.EXTRA_EVENT_ID, event.getId());
+                startActivity(intent);
+            }
+        });
+        rvAllEvents.setAdapter(adapter);
+
+        loadData();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        loadData();
+    }
+
+    private void loadData() {
+        loadInvitationsCount();
+        loadAllEvents();
+    }
+
+    private void loadInvitationsCount() {
+        FirebaseFirestore.getInstance()
+                .collection("events")
+                .whereArrayContains("selectedEntrants", deviceId)
+                .get()
+                .addOnSuccessListener(snapshot -> {
+                    int count = 0;
+                    for (DocumentSnapshot doc : snapshot.getDocuments()) {
+                        Event event = doc.toObject(Event.class);
+                        if (event != null) {
+                            boolean isEnrolled = event.getEnrolledEntrants() != null && event.getEnrolledEntrants().contains(deviceId);
+                            boolean isCancelled = event.getCancelledEntrants() != null && event.getCancelledEntrants().contains(deviceId);
+
+                            if (!isEnrolled && !isCancelled) {
+                                count++;
+                            }
+                        }
+                    }
+
+                    if (count > 0) {
+                        layoutInvitationCard.setVisibility(View.VISIBLE);
+                        tvInvitationCountSummary.setText("You have " + count + " new invitation" + (count > 1 ? "s" : "") + "!");
+                    } else {
+                        layoutInvitationCard.setVisibility(View.GONE);
+                    }
+                });
+    }
+
+    private void loadAllEvents() {
+        progressBar.setVisibility(View.VISIBLE);
+        FirebaseFirestore.getInstance()
+                .collection("events")
+                .get()
+                .addOnSuccessListener(snapshot -> {
+                    progressBar.setVisibility(View.GONE);
+                    allEventsList.clear();
+                    for (DocumentSnapshot doc : snapshot.getDocuments()) {
+                        Event event = doc.toObject(Event.class);
+                        if (event != null) {
+                            event.setId(doc.getId());
+                            allEventsList.add(event);
+                        }
+                    }
+                    adapter.notifyDataSetChanged();
+                    tvNoEvents.setVisibility(allEventsList.isEmpty() ? View.VISIBLE : View.GONE);
+                })
+                .addOnFailureListener(e -> {
+                    progressBar.setVisibility(View.GONE);
+                    Toast.makeText(this, "Error loading events", Toast.LENGTH_SHORT).show();
+                });
+    }
+}

--- a/CodeBase/app/src/main/java/com/example/codebase/FinalEntrantListAdapter.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/FinalEntrantListAdapter.java
@@ -10,6 +10,8 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.firebase.firestore.FirebaseFirestore;
+
 import java.util.ArrayList;
 
 public class FinalEntrantListAdapter extends ArrayAdapter<String> {
@@ -31,10 +33,22 @@ public class FinalEntrantListAdapter extends ArrayAdapter<String> {
         TextView entrantName = view.findViewById(R.id.entrantNameTextView);
         TextView entrantEmail = view.findViewById(R.id.entrantEmailTextView);
 
-        entrantName.setText(deviceId != null ? deviceId : "");
-        entrantEmail.setText("");
+        entrantName.setText("Loading...");
+        entrantEmail.setText(deviceId != null ? deviceId : "");
+
+        if (deviceId != null && !deviceId.isEmpty()) {
+            FirebaseFirestore.getInstance().collection("users").document(deviceId)
+                    .get()
+                    .addOnSuccessListener(documentSnapshot -> {
+                        if (documentSnapshot.exists()) {
+                            String name = documentSnapshot.getString("name");
+                            String email = documentSnapshot.getString("email");
+                            entrantName.setText(name != null ? name : "Unknown User");
+                            entrantEmail.setText(email != null ? email : deviceId);
+                        }
+                    });
+        }
 
         return view;
-
     }
 }

--- a/CodeBase/app/src/main/java/com/example/codebase/FinalEntrantListFragment.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/FinalEntrantListFragment.java
@@ -1,13 +1,10 @@
 package com.example.codebase;
 
 import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
-import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.SearchView;
@@ -15,7 +12,6 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 
 import java.util.ArrayList;
@@ -25,7 +21,6 @@ public class FinalEntrantListFragment extends Fragment {
 
     interface FinalEntrantListListener{
         Event getEvent();
-
     }
 
     private FinalEntrantListListener listener;
@@ -41,7 +36,6 @@ public class FinalEntrantListFragment extends Fragment {
     Long maxCapacity;
 
     FinalEntrantListAdapter entrantAdapter;
-
 
     @Override
     public void onAttach(@NonNull Context context) {
@@ -65,16 +59,21 @@ public class FinalEntrantListFragment extends Fragment {
 
         event = listener.getEvent();
         finalEntrants = event.getEnrolledEntrants();
+        if (finalEntrants == null) finalEntrants = new ArrayList<>();
+        
         maxCapacity = event.getMaxCapacity();
+        if (maxCapacity == null || maxCapacity == 0) maxCapacity = 1L; // Avoid division by zero
+
         entrantAdapter = new FinalEntrantListAdapter(view.getContext(), finalEntrants);
         listView.setAdapter(entrantAdapter);
 
+        int count = finalEntrants.size();
         int percentageCap = 0;
         if (maxCapacity != null && maxCapacity > 0) {
-            percentageCap = (int) ((finalEntrants.size() * 100L) / maxCapacity);
+            percentageCap = (int) ((count * 100.0) / maxCapacity);
         }
-        String capacityString = finalEntrants.size()+"/"+maxCapacity;
-        String percentageString = Integer.toString(percentageCap)+"%";
+        String capacityString = count + "/" + maxCapacity;
+        String percentageString = percentageCap + "%";
 
         capacityText.setText(capacityString);
         percentageCapacityText.setText(percentageString);
@@ -96,8 +95,4 @@ public class FinalEntrantListFragment extends Fragment {
 
         return view;
     }
-
-
-
-
 }

--- a/CodeBase/app/src/main/java/com/example/codebase/InvitationFragment.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/InvitationFragment.java
@@ -1,0 +1,83 @@
+package com.example.codebase;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+/**
+ * Fragment responsible for displaying an event invitation to the Entrant.
+ * Handles the UI for accepting or declining the invitation.
+ */
+public class InvitationFragment extends Fragment {
+
+    // These would typically be passed in via a Bundle (getArguments) or a ViewModel
+    private Event currentEvent;
+    private Entrant currentEntrant;
+
+    // The logic class we created earlier
+    private Invitations invitationManager;
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        // Inflate your layout file (e.g., res/layout/fragment_invitations.xml)
+        View view = inflater.inflate(R.layout.fragment_invitations, container, false);
+
+        // 1. Initialize the logic controller
+        invitationManager = new Invitations();
+
+        // 2. Find your buttons from the XML layout
+        Button btnAccept = view.findViewById(R.id.btnAccept);
+        Button btnDecline = view.findViewById(R.id.btnDecline);
+
+        // TODO: Retrieve the actual currentEvent and currentEntrant data here
+        // (e.g., from an Intent, Bundle arguments, or shared ViewModel)
+
+        // 3. Set up the Accept Button (Step 2 from earlier)
+        btnAccept.setOnClickListener(v -> {
+            if (currentEvent != null && currentEntrant != null) {
+                // Pass true for accepted
+                invitationManager.respondToInvitation(currentEvent, currentEntrant.getDeviceId(), true);
+
+                Toast.makeText(getContext(), "Added to the Final Entrant List!", Toast.LENGTH_SHORT).show();
+
+                // Optional: Disable buttons or close the fragment so they can't click it twice
+                btnAccept.setEnabled(false);
+                btnDecline.setEnabled(false);
+            } else {
+                Toast.makeText(getContext(), "Error: Event or Entrant data is missing.", Toast.LENGTH_SHORT).show();
+            }
+        });
+
+        // 4. Set up the Decline Button
+        btnDecline.setOnClickListener(v -> {
+            if (currentEvent != null && currentEntrant != null) {
+                // Pass false for declined
+                invitationManager.respondToInvitation(currentEvent, currentEntrant.getDeviceId(), false);
+
+                Toast.makeText(getContext(), "Invitation declined.", Toast.LENGTH_SHORT).show();
+
+                // Optional: Disable buttons or close the fragment
+                btnAccept.setEnabled(false);
+                btnDecline.setEnabled(false);
+            } else {
+                Toast.makeText(getContext(), "Error: Event or Entrant data is missing.", Toast.LENGTH_SHORT).show();
+            }
+        });
+
+        return view;
+    }
+
+    // Setter methods used to pass data into this fragment from your Activity
+    public void setEventData(Event event, Entrant entrant) {
+        this.currentEvent = event;
+        this.currentEntrant = entrant;
+    }
+}

--- a/CodeBase/app/src/main/java/com/example/codebase/Invitations.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/Invitations.java
@@ -1,0 +1,54 @@
+package com.example.codebase;
+
+import java.util.ArrayList;
+
+/**
+ * Controller class to manage Entrant invitations locally.
+ * This class modifies the Event object's lists in memory based on the user's choice.
+ */
+public class Invitations {
+    /**
+     * Processes an entrant's response to an event invitation.
+     *
+     * @param event          The event the entrant was invited to.
+     * @param deviceId       The device ID of the entrant responding.
+     * @param isAccepted     True if the entrant pressed "Accept", false if "Decline".
+     */
+    public void respondToInvitation(Event event, String deviceId, boolean isAccepted) {
+        if (event == null || deviceId == null) {
+            return; // Invalid input
+        }
+
+        ArrayList<String> selected = event.getSelectedEntrants();
+        if (selected == null) {
+            return;
+        }
+
+        // Remove from the pending invitations list (selectedEntrants)
+        selected.remove(deviceId);
+
+        if (isAccepted) {
+            // Entrant pressed "Accept" -> Add to enrolledEntrants
+            ArrayList<String> enrolled = event.getEnrolledEntrants();
+            if (enrolled == null) {
+                enrolled = new ArrayList<>();
+                event.setEnrolledEntrants(enrolled);
+            }
+            
+            if (!enrolled.contains(deviceId)) {
+                enrolled.add(deviceId);
+            }
+        } else {
+            // Entrant pressed "Decline" -> Move to cancelledEntrants
+            ArrayList<String> cancelled = event.getCancelledEntrants();
+            if (cancelled == null) {
+                cancelled = new ArrayList<>();
+                event.setCancelledEntrants(cancelled);
+            }
+            
+            if (!cancelled.contains(deviceId)) {
+                cancelled.add(deviceId);
+            }
+        }
+    }
+}

--- a/CodeBase/app/src/main/java/com/example/codebase/InvitationsActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/InvitationsActivity.java
@@ -1,0 +1,128 @@
+package com.example.codebase;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InvitationsActivity extends AppCompatActivity {
+
+    private RecyclerView rvInvitations;
+    private TextView tvNoInvitations;
+    private View progressBar;
+
+    private ExploreEventAdapter adapter;
+    private List<Event> invitationList = new ArrayList<>();
+    private String deviceId;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_invitations);
+
+        deviceId = DeviceIdManager.getOrCreateDeviceId(this);
+
+        rvInvitations = findViewById(R.id.rvInvitationsList);
+        tvNoInvitations = findViewById(R.id.tvNoInvitationsList);
+        progressBar = findViewById(R.id.invitationsProgressBar);
+
+        findViewById(R.id.btnBackInvitations).setOnClickListener(v -> finish());
+
+        rvInvitations.setLayoutManager(new LinearLayoutManager(this));
+
+        adapter = new ExploreEventAdapter(invitationList, new ExploreEventAdapter.OnInvitationActionListener() {
+            @Override
+            public void onAcceptClick(Event event) {
+                processInvitationResponse(event, true);
+            }
+
+            @Override
+            public void onDeclineClick(Event event) {
+                processInvitationResponse(event, false);
+            }
+
+            @Override
+            public void onCardClick(Event event) {
+                Intent intent = new Intent(InvitationsActivity.this, EntrantEventDetailActivity.class);
+                intent.putExtra(EntrantEventDetailActivity.EXTRA_EVENT_ID, event.getId());
+                startActivity(intent);
+            }
+        });
+        rvInvitations.setAdapter(adapter);
+
+        loadInvitations();
+    }
+
+    private void loadInvitations() {
+        progressBar.setVisibility(View.VISIBLE);
+
+        // Firestore query already filters for where user is in selectedEntrants
+        FirebaseFirestore.getInstance()
+                .collection("events")
+                .whereArrayContains("selectedEntrants", deviceId)
+                .get()
+                .addOnSuccessListener(this::populateList)
+                .addOnFailureListener(e -> {
+                    progressBar.setVisibility(View.GONE);
+                    Toast.makeText(this, "Error loading invitations", Toast.LENGTH_SHORT).show();
+                });
+    }
+
+    private void populateList(QuerySnapshot snapshot) {
+        progressBar.setVisibility(View.GONE);
+        invitationList.clear();
+
+        for (DocumentSnapshot doc : snapshot.getDocuments()) {
+            Event event = doc.toObject(Event.class);
+            if (event != null) {
+                event.setId(doc.getId());
+                
+                // US Change: Always show if in selectedEntrants, regardless of previous rejections (cancelledEntrants).
+                // Only exclude if they have already accepted (enrolledEntrants).
+                boolean isEnrolled = event.getEnrolledEntrants() != null && event.getEnrolledEntrants().contains(deviceId);
+                
+                if (!isEnrolled) {
+                    invitationList.add(event);
+                }
+            }
+        }
+
+        adapter.notifyDataSetChanged();
+        tvNoInvitations.setVisibility(invitationList.isEmpty() ? View.VISIBLE : View.GONE);
+        rvInvitations.setVisibility(invitationList.isEmpty() ? View.GONE : View.VISIBLE);
+    }
+
+    private void processInvitationResponse(Event event, boolean isAccepted) {
+        progressBar.setVisibility(View.VISIBLE);
+
+        Invitations invitationManager = new Invitations();
+        invitationManager.respondToInvitation(event, deviceId, isAccepted);
+
+        FirebaseFirestore.getInstance().collection("events").document(event.getId())
+                .update(
+                        "selectedEntrants", event.getSelectedEntrants(),
+                        "enrolledEntrants", event.getEnrolledEntrants(),
+                        "cancelledEntrants", event.getCancelledEntrants()
+                )
+                .addOnSuccessListener(aVoid -> {
+                    Toast.makeText(this, isAccepted ? "Invitation Accepted!" : "Invitation Declined.", Toast.LENGTH_SHORT).show();
+                    loadInvitations();
+                })
+                .addOnFailureListener(e -> {
+                    progressBar.setVisibility(View.GONE);
+                    Toast.makeText(this, "Failed to update response. Please try again.", Toast.LENGTH_SHORT).show();
+                });
+    }
+}

--- a/CodeBase/app/src/main/java/com/example/codebase/NotificationsActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/NotificationsActivity.java
@@ -2,7 +2,9 @@ package com.example.codebase;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.ListView;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -20,6 +22,8 @@ import java.util.HashMap;
 public class NotificationsActivity extends AppCompatActivity {
 
     private ListView listViewNotifications;
+    private View invitationCard;
+    private TextView invitationCountSummary;
 
     private final ArrayList<HashMap<String, String>> items = new ArrayList<>();
     private final ArrayList<String> eventIds = new ArrayList<>();
@@ -32,8 +36,21 @@ public class NotificationsActivity extends AppCompatActivity {
         setContentView(R.layout.activity_notifications);
 
         listViewNotifications = findViewById(R.id.listViewNotifications);
+        invitationCard = findViewById(R.id.invitationSummaryInclude);
+        invitationCountSummary = findViewById(R.id.tvInvitationCountSummary);
         deviceId = DeviceIdManager.getOrCreateDeviceId(this);
 
+        invitationCard.setOnClickListener(v ->
+                startActivity(new Intent(this, InvitationsActivity.class)));
+
+        loadInvitationSummary();
+        loadNotifications();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        loadInvitationSummary();
         loadNotifications();
     }
 
@@ -47,6 +64,39 @@ public class NotificationsActivity extends AppCompatActivity {
                         Toast.makeText(this,
                                 "Failed to load notifications",
                                 Toast.LENGTH_SHORT).show());
+    }
+
+    private void loadInvitationSummary() {
+        AppDatabase.getInstance()
+                .eventsRef
+                .whereArrayContains("selectedEntrants", deviceId)
+                .get()
+                .addOnSuccessListener(queryDocumentSnapshots -> {
+                    int invitationCount = 0;
+                    for (DocumentSnapshot doc : queryDocumentSnapshots.getDocuments()) {
+                        Event event = EventSchema.normalizeLoadedEvent(doc);
+                        if (event == null) {
+                            continue;
+                        }
+
+                        boolean isEnrolled = event.getEnrolledEntrants() != null
+                                && event.getEnrolledEntrants().contains(deviceId);
+                        if (!isEnrolled) {
+                            invitationCount++;
+                        }
+                    }
+
+                    if (invitationCount > 0) {
+                        invitationCard.setVisibility(View.VISIBLE);
+                        invitationCountSummary.setText(
+                                "You have " + invitationCount + " invitation"
+                                        + (invitationCount > 1 ? "s" : "")
+                                        + " awaiting a response.");
+                    } else {
+                        invitationCard.setVisibility(View.GONE);
+                    }
+                })
+                .addOnFailureListener(e -> invitationCard.setVisibility(View.GONE));
     }
 
     private void populateNotifications(java.util.List<DocumentSnapshot> documents) {
@@ -68,8 +118,8 @@ public class NotificationsActivity extends AppCompatActivity {
         listViewNotifications.setAdapter(adapter);
 
         listViewNotifications.setOnItemClickListener((parent, view, position, id) -> {
-            Intent intent = new Intent(this, EventDetailsActivity.class);
-            intent.putExtra("eventId", eventIds.get(position));
+            Intent intent = new Intent(this, EntrantEventDetailActivity.class);
+            intent.putExtra(EntrantEventDetailActivity.EXTRA_EVENT_ID, eventIds.get(position));
             startActivity(intent);
         });
     }

--- a/CodeBase/app/src/main/java/com/example/codebase/OrganizerEventAdapter.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/OrganizerEventAdapter.java
@@ -74,8 +74,8 @@ public class OrganizerEventAdapter extends
         }
 
         Date today = new Date();
-        List<?> selectedEntrants = event.getSelectedEntrants();
-        List<?> enrolledEntrants = event.getEnrolledEntrants();
+        List<String> selectedEntrants = event.getSelectedEntrants();
+        List<String> enrolledEntrants = event.getEnrolledEntrants();
 
         boolean selectedEmpty = selectedEntrants == null || selectedEntrants.isEmpty();
         boolean enrolledEmpty = enrolledEntrants == null || enrolledEntrants.isEmpty();

--- a/CodeBase/app/src/main/res/layout/activity_entrant_event_detail.xml
+++ b/CodeBase/app/src/main/res/layout/activity_entrant_event_detail.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#F0EDE8">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@+id/layoutButtons"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <!-- Hero Image Area -->
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="250dp">
+
+                <ImageView
+                    android:id="@+id/ivEntrantHeroPoster"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:scaleType="centerCrop"
+                    android:background="#CCCCCC"
+                    android:contentDescription="Event Poster" />
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="#66000000" />
+
+                <ImageButton
+                    android:id="@+id/btnEntrantBack"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_margin="16dp"
+                    android:paddingTop="32dp"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:src="@android:drawable/ic_media_previous"
+                    app:tint="#FFFFFF"
+                    android:contentDescription="Back" />
+
+                <TextView
+                    android:id="@+id/tvEntrantEventTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom"
+                    android:layout_margin="20dp"
+                    android:text="Event Title"
+                    android:textColor="#FFFFFF"
+                    android:textSize="24sp"
+                    android:textStyle="bold" />
+            </FrameLayout>
+
+            <!-- Event Details -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="20dp">
+
+                <TextView
+                    android:id="@+id/tvEntrantEventDate"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:drawableStartCompat="@android:drawable/ic_menu_today"
+                    android:drawablePadding="8dp"
+                    android:text="Date not set"
+                    android:textColor="#555555"
+                    android:textSize="16sp" />
+
+                <TextView
+                    android:id="@+id/tvEntrantEventLocation"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    app:drawableStartCompat="@android:drawable/ic_menu_mylocation"
+                    android:drawablePadding="8dp"
+                    android:text="Location"
+                    android:textColor="#555555"
+                    android:textSize="16sp" />
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginVertical="20dp"
+                    android:background="#DDDDDD" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="About this event"
+                    android:textColor="#111111"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/tvEntrantEventDescription"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:lineSpacingMultiplier="1.2"
+                    android:text="Event description goes here..."
+                    android:textColor="#666666"
+                    android:textSize="15sp" />
+
+            </LinearLayout>
+        </LinearLayout>
+    </ScrollView>
+
+    <!-- Bottom Buttons Container -->
+    <FrameLayout
+        android:id="@+id/layoutButtons"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:background="#FFFFFF"
+        android:elevation="8dp"
+        android:padding="16dp">
+
+        <!-- Drop Out Button (Full Width) -->
+        <Button
+            android:id="@+id/btnDropOut"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:backgroundTint="#D32F2F"
+            android:text="Drop out of event"
+            android:textColor="#FFFFFF"
+            android:visibility="gone"
+            style="?android:attr/buttonBarButtonStyle" />
+
+        <!-- Side by Side Join/Leave Buttons -->
+        <LinearLayout
+            android:id="@+id/layoutJoinLeave"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:weightSum="2"
+            style="?android:attr/buttonBarStyle"
+            android:visibility="visible">
+
+            <Button
+                android:id="@+id/btnLeaveWaitingList"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:layout_weight="1"
+                android:backgroundTint="#D32F2F"
+                android:text="Leave waiting list"
+                android:textColor="#FFFFFF"
+                style="?android:attr/buttonBarButtonStyle" />
+
+            <Button
+                android:id="@+id/btnJoinWaitingList"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:backgroundTint="#4CAF50"
+                android:text="Join waiting list"
+                android:textColor="#FFFFFF"
+                style="?android:attr/buttonBarButtonStyle" />
+        </LinearLayout>
+    </FrameLayout>
+
+    <ProgressBar
+        android:id="@+id/entrantDetailProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:visibility="gone" />
+
+</RelativeLayout>

--- a/CodeBase/app/src/main/res/layout/activity_explore_page.xml
+++ b/CodeBase/app/src/main/res/layout/activity_explore_page.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="#F0EDE8">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingTop="36dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingBottom="12dp"
+        android:gravity="center_vertical">
+
+        <ImageButton
+            android:id="@+id/btnBackExplore"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="@drawable/bg_icon_btn_light"
+            android:src="@android:drawable/ic_media_previous"
+            android:contentDescription="Back" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:text="Explore Events"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            android:textColor="#111111" />
+    </LinearLayout>
+
+    <include
+        android:id="@+id/layoutInvitationCard"
+        layout="@layout/item_invitation_summary_card"
+        android:visibility="gone" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="ALL EVENTS"
+        android:textSize="9sp"
+        android:letterSpacing="0.18"
+        android:textColor="#AAAAAA"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="8dp" />
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ProgressBar
+            android:id="@+id/exploreProgressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:visibility="gone" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rvAllEvents"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="16dp" />
+
+        <TextView
+            android:id="@+id/tvNoEventsExplore"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="No events found."
+            android:textSize="14sp"
+            android:textColor="#AAAAAA"
+            android:visibility="gone" />
+    </FrameLayout>
+</LinearLayout>

--- a/CodeBase/app/src/main/res/layout/activity_invitations.xml
+++ b/CodeBase/app/src/main/res/layout/activity_invitations.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="#F8F9FA">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        android:gravity="center_vertical"
+        android:background="#FFFFFF"
+        android:elevation="4dp">
+
+        <ImageButton
+            android:id="@+id/btnBackInvitations"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@android:drawable/ic_menu_revert"
+            android:contentDescription="Go Back"
+            app:tint="#000000" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:text="My Invitations"
+            android:textSize="22sp"
+            android:textStyle="bold"
+            android:textColor="#000000" />
+    </LinearLayout>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ProgressBar
+            android:id="@+id/invitationsProgressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:visibility="gone" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rvInvitationsList"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:padding="16dp" />
+
+        <TextView
+            android:id="@+id/tvNoInvitationsList"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="You haven't received any invitations yet."
+            android:textSize="16sp"
+            android:textColor="#888888"
+            android:visibility="gone" />
+    </FrameLayout>
+</LinearLayout>

--- a/CodeBase/app/src/main/res/layout/activity_notifications.xml
+++ b/CodeBase/app/src/main/res/layout/activity_notifications.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -15,8 +16,15 @@
         android:textColor="@color/textPrimary"
         android:layout_marginBottom="16dp" />
 
+    <include
+        android:id="@+id/invitationSummaryInclude"
+        layout="@layout/item_invitation_summary_card"
+        android:visibility="gone" />
+
     <ListView
         android:id="@+id/listViewNotifications"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginTop="8dp" />
 </LinearLayout>

--- a/CodeBase/app/src/main/res/layout/activity_organizer.xml
+++ b/CodeBase/app/src/main/res/layout/activity_organizer.xml
@@ -11,7 +11,6 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <!-- Top title -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -30,7 +29,6 @@
                 android:textColor="@color/textPrimary" />
         </LinearLayout>
 
-        <!-- Event list area -->
         <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="0dp"
@@ -53,7 +51,6 @@
         </FrameLayout>
     </LinearLayout>
 
-    <!-- Floating create button -->
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fabCreateEvent"
         android:layout_width="wrap_content"
@@ -221,5 +218,4 @@
 
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
-
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/CodeBase/app/src/main/res/layout/fragment_invitations.xml
+++ b/CodeBase/app/src/main/res/layout/fragment_invitations.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="24dp"
+    android:background="#F0EDE8">
+
+    <TextView
+        android:id="@+id/tvInvitationTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Event Invitation"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:textColor="#111111"
+        android:layout_marginBottom="16dp" />
+
+    <TextView
+        android:id="@+id/tvInvitationMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="You have been invited to an event! Would you like to accept or decline?"
+        android:textSize="16sp"
+        android:textColor="#666666"
+        android:gravity="center"
+        android:layout_marginBottom="32dp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:weightSum="2">
+
+        <Button
+            android:id="@+id/btnDecline"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginEnd="8dp"
+            android:text="Decline"
+            android:textColor="#D32F2F"
+            style="?attr/materialButtonOutlinedStyle" />
+
+        <Button
+            android:id="@+id/btnAccept"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="8dp"
+            android:text="Accept"
+            android:backgroundTint="#4CAF50"
+            android:textColor="#FFFFFF" />
+    </LinearLayout>
+</LinearLayout>

--- a/CodeBase/app/src/main/res/layout/item_explore_event.xml
+++ b/CodeBase/app/src/main/res/layout/item_explore_event.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="12dp"
+    app:cardCornerRadius="12dp"
+    app:cardElevation="3dp"
+    app:cardBackgroundColor="#FFFFFF"
+    android:foreground="?android:attr/selectableItemBackground">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/tvExploreEventTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Event Title"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:textColor="#000000" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="Congratulations! You have been selected in the lottery for this event. Please respond to secure your spot."
+            android:textSize="14sp"
+            android:textColor="#666666" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:orientation="horizontal"
+            android:weightSum="2">
+
+            <Button
+                android:id="@+id/btnExploreDecline"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginEnd="8dp"
+                android:text="Decline"
+                android:textColor="#D32F2F"
+                app:strokeColor="#D32F2F"
+                app:strokeWidth="1dp"
+                style="?attr/materialButtonOutlinedStyle" />
+
+            <Button
+                android:id="@+id/btnExploreAccept"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginStart="8dp"
+                android:text="Accept"
+                android:backgroundTint="#4CAF50"
+                android:textColor="#FFFFFF" />
+        </LinearLayout>
+    </LinearLayout>
+</androidx.cardview.widget.CardView>

--- a/CodeBase/app/src/main/res/layout/item_invitation_summary_card.xml
+++ b/CodeBase/app/src/main/res/layout/item_invitation_summary_card.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/cardInvitations"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="16dp"
+    android:layout_marginEnd="16dp"
+    android:layout_marginBottom="12dp"
+    app:cardCornerRadius="12dp"
+    app:cardElevation="4dp"
+    app:cardBackgroundColor="#E8F5E9"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        android:gravity="center_vertical">
+
+        <ImageView
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:src="@android:drawable/ic_menu_send"
+            app:tint="#2E7D32" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:layout_marginStart="16dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Event Invitations"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                android:textColor="#2E7D32" />
+
+            <TextView
+                android:id="@+id/tvInvitationCountSummary"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Checking for invitations..."
+                android:textSize="14sp"
+                android:textColor="#4CAF50" />
+        </LinearLayout>
+
+        <ImageView
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@android:drawable/ic_media_next"
+            app:tint="#2E7D32" />
+    </LinearLayout>
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
## Summary

  This PR merges Karan’s entrant invitation flow into dev-chetan and integrates it
  with the current app navigation so the relevant entrant stories are actually
  reachable in the active UI.

  ## What changed

  - Merged entrant-side event and invitation screens into the branch:
      - EntrantEventDetailActivity
      - InvitationsActivity
      - ExplorePageActivity
      - ExploreEventAdapter
      - InvitationFragment
      - Invitations
  - Preserved the existing schema and organizer-side changes already present on dev-
    chetan.
  - Kept the existing app UI direction instead of replacing the current screens
    wholesale.

  ## Navigation integration

  - Updated Browse Events so non-organizers now open the entrant event detail
    screen.
  - This makes the following flows reachable from the current Explore path:
      - Join Waiting List
      - Leave Waiting List
  - Updated the Notifications tab to surface pending invitations using an invitation
    summary card.
  - Tapping that card opens the invitations screen where the user can:
      - Accept Invitation
      - Decline Invitation
  - Updated invitation item clicks to open the entrant event detail screen rather
    than the organizer event detail screen.

  ## UI and crash fix

  - Added the invitation summary card to the existing notifications screen.
  - Fixed a crash in NotificationsActivity caused by looking up the included
    invitation card with the wrong view ID.

  ## Included files

  This PR includes both the merged entrant invitation feature files and the
  integration changes needed to expose them through the currently used app screens.