### PR TITLE
Add first-run profile creation flow after device registration

### DIFF
--- a/CodeBase/app/src/main/java/com/example/codebase/ProfileSettingsActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/ProfileSettingsActivity.java
@@ -1,5 +1,7 @@
 package com.example.codebase;
 
+import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Patterns;
@@ -16,6 +18,11 @@ import androidx.appcompat.app.AppCompatActivity;
  */
 public class ProfileSettingsActivity extends AppCompatActivity {
 
+    public static final String EXTRA_FIRST_RUN = "extra_first_run";
+
+    private boolean isFirstRun;
+    private TextView textViewTitle;
+    private TextView textViewSubtitle;
     private TextView textViewDeviceId;
     private EditText editTextName;
     private EditText editTextEmail;
@@ -27,21 +34,28 @@ public class ProfileSettingsActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_profile_settings);
 
+        isFirstRun = getIntent().getBooleanExtra(EXTRA_FIRST_RUN, false);
+
+        textViewTitle = findViewById(R.id.textViewTitle);
+        textViewSubtitle = findViewById(R.id.textViewSubtitle);
         textViewDeviceId = findViewById(R.id.textViewDeviceId);
         editTextName = findViewById(R.id.editTextName);
         editTextEmail = findViewById(R.id.editTextEmail);
         editTextPhone = findViewById(R.id.editTextPhone);
         buttonSaveChanges = findViewById(R.id.buttonSaveChanges);
 
-        // Show current device ID
-        textViewDeviceId.setText(DeviceIdManager.getOrCreateDeviceId(this));
+        applyMode();
+        textViewDeviceId.setText(
+                getString(
+                        R.string.profile_settings_device_id_value,
+                        DeviceIdManager.getOrCreateDeviceId(this)
+                )
+        );
 
-        // Load cached data first if available
         if (AppCache.getInstance().hasCachedUser()) {
             populateFields(AppCache.getInstance().getCachedUser());
         }
 
-        // Refresh from Firestore
         UserRepository.loadUserProfile(this, new UserRepository.UserCallback() {
             @Override
             public void onUserLoaded(User user) {
@@ -50,25 +64,31 @@ public class ProfileSettingsActivity extends AppCompatActivity {
 
             @Override
             public void onError(Exception e) {
-                // Silent for now
+                // Leave fields empty if Firestore load fails.
             }
         });
 
         buttonSaveChanges.setOnClickListener(v -> saveProfile());
     }
 
-    /**
-     * Fill text fields with existing user data.
-     */
+    private void applyMode() {
+        if (isFirstRun) {
+            textViewTitle.setText(R.string.profile_settings_first_run_title);
+            textViewSubtitle.setText(R.string.profile_settings_first_run_subtitle);
+            buttonSaveChanges.setText(R.string.profile_settings_continue);
+        } else {
+            textViewTitle.setText(R.string.profile_settings_edit_title);
+            textViewSubtitle.setText(R.string.profile_settings_edit_subtitle);
+            buttonSaveChanges.setText(R.string.profile_settings_save);
+        }
+    }
+
     private void populateFields(User user) {
         editTextName.setText(user.getName());
         editTextEmail.setText(user.getEmail());
         editTextPhone.setText(user.getPhoneNumber());
     }
 
-    /**
-     * Validate and save profile.
-     */
     private void saveProfile() {
         String name = editTextName.getText().toString().trim();
         String email = editTextEmail.getText().toString().trim();
@@ -95,10 +115,26 @@ public class ProfileSettingsActivity extends AppCompatActivity {
                 email,
                 phone,
                 () -> {
-                    Toast.makeText(this, "Profile saved", Toast.LENGTH_SHORT).show();
+                    SharedPreferences prefs =
+                            getSharedPreferences(WelcomeActivity.PREFS_NAME, MODE_PRIVATE);
+                    prefs.edit().putBoolean(WelcomeActivity.KEY_PROFILE_PENDING, false).apply();
+
+                    Toast.makeText(this, getString(R.string.profile_settings_saved), Toast.LENGTH_SHORT).show();
+                    if (isFirstRun) {
+                        startActivity(new Intent(this, OrganizerActivity.class));
+                    }
                     finish();
                 },
                 e -> Toast.makeText(this, "Failed to save profile", Toast.LENGTH_SHORT).show()
         );
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (isFirstRun) {
+            Toast.makeText(this, getString(R.string.profile_settings_required), Toast.LENGTH_SHORT).show();
+            return;
+        }
+        super.onBackPressed();
     }
 }

--- a/CodeBase/app/src/main/java/com/example/codebase/SplashActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/SplashActivity.java
@@ -1,6 +1,7 @@
 package com.example.codebase;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.TextView;
@@ -15,13 +16,6 @@ import com.google.firebase.firestore.DocumentReference;
  * navigating to the main activity.
  */
 public class SplashActivity extends AppCompatActivity {
-    /**
-     * Initializes the splash screen, handles device ID logic, and manages navigation.
-     *
-     * @param savedInstanceState If the activity is being re-initialized after
-     *                           previously being shut down then this Bundle contains the data it most
-     *                           recently supplied in onSaveInstanceState(Bundle).
-     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -30,7 +24,6 @@ public class SplashActivity extends AppCompatActivity {
         String deviceId = DeviceIdManager.getOrCreateDeviceId(this);
 
         TextView deviceIdText = findViewById(R.id.deviceIdText);
-        // Display a shortened version of the UUID (first 8 characters)
         String displayId = DeviceIdManager.getShortenedId(deviceId);
         deviceIdText.setText("Device ID: " + displayId + "...");
 
@@ -41,30 +34,38 @@ public class SplashActivity extends AppCompatActivity {
         userRef.get().addOnCompleteListener(task -> {
             if (task.isSuccessful()) {
                 if (!task.getResult().exists()) {
-                    // First launch — register this device as a new user
                     userRef.set(new User(deviceId))
-                            .addOnSuccessListener(v ->
-                                    Log.d("Firestore", "New user registered: " + deviceId))
-                            .addOnFailureListener(e ->
-                                    Log.e("Firestore", "Registration failed", e));
+                            .addOnSuccessListener(v -> {
+                                Log.d("Firestore", "New user registered: " + deviceId);
+                                launchProfileCreation();
+                            })
+                            .addOnFailureListener(e -> {
+                                Log.e("Firestore", "Registration failed", e);
+                                navigateToMain();
+                            });
+                } else {
+                    navigateToMain();
                 }
-                // Navigate regardless — existing or new user
-                navigateToMain();
             } else {
-                // Firestore unreachable — still let them in, retry later
                 Log.e("Firestore", "Failed to check user", task.getException());
                 navigateToMain();
             }
         });
     }
 
-    /**
-     * Navigates to OrganizerActivity and finishes the splash activity.
-     */
     private void navigateToMain() {
-        // Check for unread notifications on every app launch
         SelectedNotificationChecker.checkAndShow(this);
         startActivity(new Intent(this, OrganizerActivity.class));
+        finish();
+    }
+
+    private void launchProfileCreation() {
+        SharedPreferences prefs = getSharedPreferences(WelcomeActivity.PREFS_NAME, MODE_PRIVATE);
+        prefs.edit().putBoolean(WelcomeActivity.KEY_PROFILE_PENDING, true).apply();
+
+        Intent intent = new Intent(this, ProfileSettingsActivity.class);
+        intent.putExtra(ProfileSettingsActivity.EXTRA_FIRST_RUN, true);
+        startActivity(intent);
         finish();
     }
 }

--- a/CodeBase/app/src/main/java/com/example/codebase/WelcomeActivity.java
+++ b/CodeBase/app/src/main/java/com/example/codebase/WelcomeActivity.java
@@ -26,6 +26,7 @@ public class WelcomeActivity extends AppCompatActivity {
 
     public static final String PREFS_NAME     = "event_lottery_prefs";
     public static final String KEY_ROLE       = "user_role";
+    public static final String KEY_PROFILE_PENDING = "profile_setup_pending";
     public static final String ROLE_USER      = "ENTRANT";
     public static final String ROLE_ADMIN     = "ADMIN";
 
@@ -99,6 +100,10 @@ public class WelcomeActivity extends AppCompatActivity {
         if (!isRegistered) {
             prefs.edit().putBoolean(RoleCheckActivity.KEY_REGISTERED, true).apply();
             startActivity(new Intent(this, SplashActivity.class));
+        } else if (prefs.getBoolean(KEY_PROFILE_PENDING, false)) {
+            Intent intent = new Intent(this, ProfileSettingsActivity.class);
+            intent.putExtra(ProfileSettingsActivity.EXTRA_FIRST_RUN, true);
+            startActivity(intent);
         } else {
             // Routing to OrganizerActivity as the primary screen for both roles for now
             startActivity(new Intent(this, OrganizerActivity.class));

--- a/CodeBase/app/src/main/res/layout/activity_profile_settings.xml
+++ b/CodeBase/app/src/main/res/layout/activity_profile_settings.xml
@@ -1,81 +1,182 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Profile settings screen -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#06152B">
+    android:background="@color/pageBg"
+    android:clipToPadding="false">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:padding="20dp">
+        android:paddingHorizontal="24dp"
+        android:paddingTop="28dp"
+        android:paddingBottom="32dp">
 
         <TextView
-            android:layout_width="wrap_content"
+            android:id="@+id/textViewTitle"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Profile Settings"
-            android:textColor="@android:color/white"
-            android:textSize="24sp"
-            android:textStyle="bold"
-            android:layout_marginBottom="20dp" />
+            android:text="@string/profile_settings_first_run_title"
+            android:textColor="@color/textPrimary"
+            android:textSize="32sp"
+            android:fontFamily="serif"
+            android:textStyle="bold" />
 
         <TextView
-            android:layout_width="wrap_content"
+            android:id="@+id/textViewSubtitle"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="DEVICE IDENTIFICATION"
-            android:textColor="#4EA1FF"
-            android:textStyle="bold"
-            android:layout_marginBottom="8dp" />
+            android:layout_marginTop="8dp"
+            android:text="@string/profile_settings_first_run_subtitle"
+            android:textColor="@color/textSecondary"
+            android:textSize="14sp" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            app:cardBackgroundColor="@color/surface"
+            app:cardCornerRadius="18dp"
+            app:cardElevation="0dp"
+            app:strokeColor="@color/border"
+            app:strokeWidth="1dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="20dp">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/profile_settings_device_id_label"
+                    android:textAllCaps="true"
+                    android:textColor="@color/textMuted"
+                    android:textSize="9sp"
+                    android:fontFamily="sans-serif-medium"
+                    android:letterSpacing="0.18" />
+
+                <TextView
+                    android:id="@+id/textViewDeviceId"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:textColor="@color/textPrimary"
+                    android:textSize="14sp" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
 
         <TextView
-            android:id="@+id/textViewDeviceId"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@android:color/white"
-            android:background="#0B1E3A"
-            android:padding="12dp"
-            android:layout_marginBottom="24dp" />
-
-        <EditText
-            android:id="@+id/editTextName"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Full Name"
-            android:textColorHint="#9FB3D1"
-            android:textColor="@android:color/white"
-            android:background="#0B1E3A"
-            android:padding="16dp"
-            android:layout_marginBottom="16dp" />
+            android:layout_marginTop="24dp"
+            android:text="@string/profile_settings_name_label"
+            android:textColor="@color/textSecondary"
+            android:textSize="12sp" />
 
-        <EditText
-            android:id="@+id/editTextEmail"
+        <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Email Address"
-            android:textColorHint="#9FB3D1"
-            android:textColor="@android:color/white"
-            android:inputType="textEmailAddress"
-            android:background="#0B1E3A"
-            android:padding="16dp"
-            android:layout_marginBottom="16dp" />
+            android:layout_marginTop="8dp"
+            app:cardBackgroundColor="@color/surface"
+            app:cardCornerRadius="16dp"
+            app:cardElevation="0dp"
+            app:strokeColor="@color/border"
+            app:strokeWidth="1dp">
 
-        <EditText
-            android:id="@+id/editTextPhone"
+            <EditText
+                android:id="@+id/editTextName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                android:hint="@string/profile_settings_name_hint"
+                android:importantForAutofill="yes"
+                android:inputType="textPersonName"
+                android:minHeight="52dp"
+                android:paddingHorizontal="16dp"
+                android:paddingVertical="14dp"
+                android:textColor="@color/textPrimary"
+                android:textColorHint="@color/textMuted" />
+        </com.google.android.material.card.MaterialCardView>
+
+        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Phone Number"
-            android:textColorHint="#9FB3D1"
-            android:textColor="@android:color/white"
-            android:inputType="phone"
-            android:background="#0B1E3A"
-            android:padding="16dp"
-            android:layout_marginBottom="20dp" />
+            android:layout_marginTop="18dp"
+            android:text="@string/profile_settings_email_label"
+            android:textColor="@color/textSecondary"
+            android:textSize="12sp" />
 
-        <Button
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            app:cardBackgroundColor="@color/surface"
+            app:cardCornerRadius="16dp"
+            app:cardElevation="0dp"
+            app:strokeColor="@color/border"
+            app:strokeWidth="1dp">
+
+            <EditText
+                android:id="@+id/editTextEmail"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                android:hint="@string/profile_settings_email_hint"
+                android:importantForAutofill="yes"
+                android:inputType="textEmailAddress"
+                android:minHeight="52dp"
+                android:paddingHorizontal="16dp"
+                android:paddingVertical="14dp"
+                android:textColor="@color/textPrimary"
+                android:textColorHint="@color/textMuted" />
+        </com.google.android.material.card.MaterialCardView>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="18dp"
+            android:text="@string/profile_settings_phone_label"
+            android:textColor="@color/textSecondary"
+            android:textSize="12sp" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            app:cardBackgroundColor="@color/surface"
+            app:cardCornerRadius="16dp"
+            app:cardElevation="0dp"
+            app:strokeColor="@color/border"
+            app:strokeWidth="1dp">
+
+            <EditText
+                android:id="@+id/editTextPhone"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                android:hint="@string/profile_settings_phone_hint"
+                android:importantForAutofill="yes"
+                android:inputType="phone"
+                android:minHeight="52dp"
+                android:paddingHorizontal="16dp"
+                android:paddingVertical="14dp"
+                android:textColor="@color/textPrimary"
+                android:textColorHint="@color/textMuted" />
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/buttonSaveChanges"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Save Changes" />
+            android:layout_height="56dp"
+            android:layout_marginTop="28dp"
+            android:text="@string/profile_settings_continue"
+            android:textAllCaps="false"
+            android:textColor="@color/white"
+            app:backgroundTint="@color/primaryAccent"
+            app:cornerRadius="100dp" />
     </LinearLayout>
 </ScrollView>

--- a/CodeBase/app/src/main/res/values/strings_organizer.xml
+++ b/CodeBase/app/src/main/res/values/strings_organizer.xml
@@ -34,6 +34,22 @@
     <string name="notifications_empty_subtitle">Event updates and invitation responses will appear here.</string>
     <string name="notifications_invitation_title">Event Invitations</string>
     <string name="notifications_invitation_loading">Checking for invitations...</string>
+    <string name="profile_settings_first_run_title">Create Your Profile</string>
+    <string name="profile_settings_first_run_subtitle">Add your contact details before continuing into the app.</string>
+    <string name="profile_settings_edit_title">Edit Profile</string>
+    <string name="profile_settings_edit_subtitle">Keep your contact information up to date.</string>
+    <string name="profile_settings_device_id_label">Device ID</string>
+    <string name="profile_settings_device_id_value">Device ID: %1$s</string>
+    <string name="profile_settings_name_label">Name</string>
+    <string name="profile_settings_email_label">Email Address</string>
+    <string name="profile_settings_phone_label">Phone Number</string>
+    <string name="profile_settings_name_hint">Enter your full name</string>
+    <string name="profile_settings_email_hint">Enter your email address</string>
+    <string name="profile_settings_phone_hint">Enter your phone number</string>
+    <string name="profile_settings_continue">Continue</string>
+    <string name="profile_settings_save">Save Changes</string>
+    <string name="profile_settings_saved">Profile saved</string>
+    <string name="profile_settings_required">Complete your profile to continue.</string>
 
     <!-- Event Detail — Header -->
     <string name="back_button_desc">Go back</string>


### PR DESCRIPTION
## Summary

  This PR adds a first-run profile creation step immediately after a new device ID
  is registered in Firestore.

  Instead of sending first-time users straight into the app after splash, the flow
  now requires them to provide their name, email address, and phone number before
  continuing. This brings the onboarding flow in line with US 01.02.01 from the
  project description.

  ## What changed

  - Added a first-run profile gate after device registration in SplashActivity
  - Added a persistent profile_setup_pending flag in WelcomeActivity
  - Prevented first-time users from bypassing profile creation on later launches
    until the form is completed
  - Updated ProfileSettingsActivity to support:
      - first-run onboarding mode
      - normal edit mode
  - On successful first-run save:
      - user profile is written to Firestore
      - pending setup flag is cleared
      - user is routed into the main app flow
  - Back navigation is blocked during first-run setup so profile completion is
    required

  ## UI updates

  - Restyled the profile settings screen to match the app’s current Airy Minimal
    theme
  - Added:
      - large onboarding title/subtitle
      - device ID summary card
      - styled input fields for name, email, and phone
      - primary CTA button for continuing into the app

  ## Files touched

  - SplashActivity.java
  - WelcomeActivity.java
  - ProfileSettingsActivity.java
  - activity_profile_settings.xml
  - strings_organizer.xml

  ## User story impact

  This PR is intended to fully support:

  - US 01.02.01 As an entrant, I want to provide my personal information such as
    name, email and optional phone number in the app